### PR TITLE
fix: no such file patch

### DIFF
--- a/packages/vxrn/src/utils/getOptionsFilled.ts
+++ b/packages/vxrn/src/utils/getOptionsFilled.ts
@@ -1,13 +1,18 @@
 import { join } from 'node:path'
 import { readPackageJSON } from 'pkg-types'
+import { createRequire } from 'module'
 import FSExtra from 'fs-extra'
 import type { VXRNConfig } from '../types'
+
+const require = createRequire(import.meta.url)
 
 export type VXRNConfigFilled = Awaited<ReturnType<typeof getOptionsFilled>>
 
 export async function getOptionsFilled(options: VXRNConfig) {
   const { host = '127.0.0.1', root = process.cwd(), port = 8081 } = options
-  const packageRootDir = join(import.meta.url ?? __filename, '..', '..', '..').replace('file:', '')
+  
+  const packageRootDir = join(require.resolve('vxrn'), '../../..')
+
   const cacheDir = join(root, 'node_modules', '.cache', 'vxrn')
   const internalPatchesDir = join(packageRootDir, 'patches')
   const userPatchesDir = join(root, 'patches')


### PR DESCRIPTION
fixes this:

```
 🥺 couldn't patch [Error: ENOENT: no such file or directory, lstat '/home/aslemammad/oss/vxrn/packages/vxrn/dist/patches/react-native-screens+3.22.1.patch'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'lstat',
  path: '/home/aslemammad/oss/vxrn/packages/vxrn/dist/patches/react-native-screens+3.22.1.patch'
}
```