### PR TITLE
chore: refine TS types

### DIFF
--- a/packages/vxrn/package.json
+++ b/packages/vxrn/package.json
@@ -60,6 +60,7 @@
     "@biomejs/biome": "^1.6.3",
     "@tamagui/build": "^1.100.0",
     "@types/find-node-modules": "^2.1.2",
+    "@types/node": "^20.12.7",
     "@types/ws": "^8.5.10",
     "depcheck": "^1.4.7",
     "rollup": "^3.29.4"

--- a/packages/vxrn/src/exports/clean.ts
+++ b/packages/vxrn/src/exports/clean.ts
@@ -39,8 +39,7 @@ export const clean = async (rest: VXRNOptions) => {
 
 function throwIfNotMissingError(err: unknown) {
   if (err instanceof Error) {
-    // @ts-expect-error wtf
-    if (err.code !== 'ENOENT') {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
       throw Error
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14965,6 +14965,7 @@ __metadata:
     "@hono/node-server": ^1.11.1
     "@tamagui/build": ^1.100.0
     "@types/find-node-modules": ^2.1.2
+    "@types/node": ^20.12.7
     "@types/ws": ^8.5.10
     "@vitejs/plugin-react-swc": ^3.6.0
     "@vxrn/react-native-prebuilt": 1.1.133


### PR DESCRIPTION
It seems there isn’t a better way to do this for now since the [SystemError](https://nodejs.org/docs/latest-v22.x/api/errors.html#class-systemerror) class which defines `.code` property is not exported by Node.js.