### PR TITLE
chore: let vxrn build output only esm

### DIFF
--- a/packages/vxrn/package.json
+++ b/packages/vxrn/package.json
@@ -4,8 +4,7 @@
   "source": "src/index.ts",
   "types": "./types/index.d.ts",
   "type": "module",
-  "main": "dist/cjs",
-  "module": "dist/esm",
+  "module": "dist",
   "publishConfig": {
     "access": "public"
   },
@@ -22,13 +21,11 @@
     "./react-native-template.js": "./react-native-template.js",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.mjs",
-      "require": "./dist/cjs/index.js"
+      "default": "./dist/index.mjs"
     },
     "./serve": {
       "types": "./types/exports/createServer.d.ts",
-      "import": "./dist/esm/exports/createServer.mjs",
-      "require": "./dist/cjs/exports/createServer.js"
+      "default": "./dist/exports/createServer.mjs"
     }
   },
   "dependencies": {

--- a/packages/vxrn/run.mjs
+++ b/packages/vxrn/run.mjs
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-import './dist/esm/cli.mjs'
+import './dist/cli.mjs'


### PR DESCRIPTION
Since the CommonJS files are not used anyway and might disturb JS debuggers from finding the correct built file to execute.