### PR TITLE
chore(logger): use the vite way to log things

### DIFF
--- a/packages/vxrn/package.json
+++ b/packages/vxrn/package.json
@@ -50,6 +50,7 @@
     "h3-proxy": "^1.13.0",
     "hono": "^4.3.10",
     "import-meta-resolve": "^4.1.0",
+    "picocolors": "^1.0.0",
     "pkg-types": "^1.0.3",
     "vite": "6.0.0-alpha.18",
     "vite-bundle-analyzer": "^0.9.4",

--- a/packages/vxrn/src/plugins/expoManifestRequestHandlerPlugin.ts
+++ b/packages/vxrn/src/plugins/expoManifestRequestHandlerPlugin.ts
@@ -3,6 +3,7 @@ import module from 'node:module'
 import { TLSSocket } from 'node:tls'
 
 import type { Plugin } from 'vite'
+import colors from 'picocolors'
 
 // Can support more [options](https://github.com/expo/expo/blob/sdk-50/packages/%40expo/cli/src/start/server/middleware/ManifestMiddleware.ts#L113-L121) in the future.
 type ExpoManifestRequestHandlerPluginConfig = {
@@ -22,6 +23,9 @@ export function expoManifestRequestHandlerPlugin(
     name: 'vxrn:expo-manifest-request-handler',
 
     configureServer(server) {
+      const { logger } = server.config
+      const defaultLogOptions = { timestamp: true }
+
       // Add a middleware to Vite's internal Connect server to handle the Expo Manifest Request.
       server.middlewares.use(async (req, res, next) => {
         if (!req.headers['expo-platform']) {
@@ -54,20 +58,30 @@ export function expoManifestRequestHandlerPlugin(
             expoGoManifestHandlerMiddlewareImportError instanceof Error &&
             (expoGoManifestHandlerMiddlewareImportError as any).code === 'MODULE_NOT_FOUND'
           ) {
-            console.warn(
-              `Failed to locate Expo SDK in your project: ${expoGoManifestHandlerMiddlewareImportError}`
+            logger.warn(
+              colors.yellow(
+                `Failed to locate Expo SDK in your project: ${expoGoManifestHandlerMiddlewareImportError}`
+              ),
+              defaultLogOptions
             )
           } else {
-            console.warn(
-              `Failed to import Expo SDK from your project: ${expoGoManifestHandlerMiddlewareImportError}`
+            logger.warn(
+              colors.yellow(
+                `Failed to import Expo SDK from your project: ${expoGoManifestHandlerMiddlewareImportError}`
+              ),
+              defaultLogOptions
             )
           }
 
-          console.warn(
-            'Ignoring the error and proceeding without handling the Expo manifest request.'
+          logger.warn(
+            'Ignoring the error and respond with preset manifest content, which may not work with Expo Go or your development build.',
+            defaultLogOptions
           )
-          console.warn(
-            `Is this a Expo project, or are you using a supported version of Expo SDK? (${projectRoot})`
+          logger.warn(
+            colors.yellow(
+              `Is this a Expo project, or are you using a supported version of Expo SDK? (${projectRoot})`
+            ),
+            defaultLogOptions
           )
 
           const json = getIndexJsonResponse(options)

--- a/yarn.lock
+++ b/yarn.lock
@@ -14897,6 +14897,7 @@ __metadata:
     h3-proxy: ^1.13.0
     hono: ^4.3.10
     import-meta-resolve: ^4.1.0
+    picocolors: ^1.0.0
     pkg-types: ^1.0.3
     rollup: ^3.29.4
     vite: 6.0.0-alpha.18


### PR DESCRIPTION
* Adds a `picocolors` dependency to `vxrn.
  * `picocolors` is also used by Vite but is bundled inside it. Seems that there's no way to access the bundled `picocolors` so we have to add that dependency.
  * It seems that Babel is already using it as a dependency anyway.

## The logs now look like this

![](https://github.com/user-attachments/assets/4c86e3c2-0724-4f59-ad6a-47ba2bb8ce8e)

* The `[vite]` prefix is not currently configurable unless we [create our own logger](https://github.com/vitejs/vite/blob/v6.0.0-alpha.18/packages/vite/src/node/logger.ts#L70-L79).