### PR TITLE
fix(react-native-prebuilt): inconsistent JSX runtime

### DIFF
--- a/packages/react-native-prebuilt/src/index.ts
+++ b/packages/react-native-prebuilt/src/index.ts
@@ -102,6 +102,7 @@ export async function buildReactNative(options: BuildOptions = {}) {
     entryPoints: [resolveFile('react-native')],
     format: 'cjs',
     target: 'node20',
+    // Note: JSX is actually being transformed by the "remove-flow" plugin defined underneath, not by esbuild. The following JSX options may not actually make a difference.
     jsx: 'transform',
     jsxFactory: 'react',
     allowOverwrite: true,
@@ -158,7 +159,7 @@ export async function buildReactNative(options: BuildOptions = {}) {
               const code = await readFile(input.path, 'utf-8')
 
               // omg so ugly but no class support?
-              const outagain = await transformFlow(code)
+              const outagain = await transformFlow(code, { development: true })
 
               return {
                 contents: outagain,

--- a/packages/vite-flow/src/index.ts
+++ b/packages/vite-flow/src/index.ts
@@ -2,13 +2,27 @@ import type { FilterPattern, PluginOption } from 'vite'
 import { createFilter } from 'vite'
 import babel from '@babel/core'
 
-export async function transformFlow(input: string) {
+export async function transformFlow(
+  input: string,
+  { development = false }: { development?: boolean } = {}
+) {
   return await new Promise<string>((res, rej) => {
     babel.transform(
       input,
       {
-        presets: ['module:metro-react-native-babel-preset'],
-        plugins: [['@babel/plugin-transform-private-methods', { loose: true }]],
+        presets: [
+          [
+            'module:metro-react-native-babel-preset',
+            {
+              // To use the `@babel/plugin-transform-react-jsx` plugin for JSX.
+              useTransformReactJSXExperimental: true,
+            },
+          ],
+        ],
+        plugins: [
+          ['@babel/plugin-transform-react-jsx', { development }],
+          ['@babel/plugin-transform-private-methods', { loose: true }],
+        ],
       },
       (err: any, result) => {
         if (!result || err) rej(err || 'no res')

--- a/packages/vite-flow/types/index.d.ts
+++ b/packages/vite-flow/types/index.d.ts
@@ -1,5 +1,7 @@
 import type { FilterPattern, PluginOption } from 'vite';
-export declare function transformFlow(input: string): Promise<string>;
+export declare function transformFlow(input: string, { development }?: {
+    development?: boolean;
+}): Promise<string>;
 export type Options = {
     include?: FilterPattern;
     exclude?: FilterPattern;


### PR DESCRIPTION
## TL;DR

The JSX runtime between the pre-bundled `react-native` and the one being used during develop is inconsistent, causing annoying warnings to show.

The pre-bundled `react-native` is compiled to using production JSX, but while in development, development JSX is being used.

## Details

I’m seeing these `Each child in a list should have a unique "key" prop` warnings while running vxrn projects:
![](https://github.com/user-attachments/assets/e2dd8920-7ad2-46d1-a46f-bb83b798a581)

The warnings are coming from React Native’s internal components, such as `LogBoxLogNotification`

![](https://github.com/user-attachments/assets/d7170d9f-7c58-44f6-9bd6-dd516793f68d)

I checked the pre-built react native code (`node_modules/.vxrn/react-native.js`) and noticed that it’s using the production version of JSX runtime (`_jsxRuntime.jsx`) but not the development version (`_jsxRuntime.jsxDEV`):

```js
    function LogBoxLogNotification(props) {
      var totalLogCount = props.totalLogCount, level = props.level, log = props.log;
      React.useEffect(function() {
        LogBoxData.symbolicateLogLazy(log);
      }, [log]);
      return (0, _jsxRuntime.jsx)(_View.default, { style: toastStyles.container, children: (0, _jsxRuntime.jsx)(_LogBoxButton.default, { onPress: props.onPressOpen, style: toastStyles.press, backgroundColor: { default: LogBoxStyle.getBackgroundColor(1), pressed: LogBoxStyle.getBackgroundColor(0.9) }, children: (0, _jsxRuntime.jsxs)(_View.default, { style: toastStyles.content, children: [(0, _jsxRuntime.jsx)(CountBadge, { count: totalLogCount, level }), (0, _jsxRuntime.jsx)(Message, { message: log.message }), (0, _jsxRuntime.jsx)(DismissButton, { onPress: props.onPressDismiss })] }) }) });
    }
```

While JSX in the project is using `reactJsxRuntime.jsxDEV`. I think this inconsistency is the cause of the problem.

Has been tweaking esbuild configs inside `react-native-prebuilt` to get the react native build use dev runtime, until I found that JSX transformation is actually handled by the `'remove-flow'` plugin’s  `transformFlow` function, not esbuild. The `transformFlow` function uses Babel with `metro-react-native-babel-preset` which will transform JSX.

Looked into the source code of `metro-react-native-babel-preset` and it seems that it’s [using `@babel/plugin-transform-react-jsx` without the `development` setting](https://github.com/facebook/metro/blob/28c967c9731b66e4088c0ed835ee8d91d920dfd7/packages/metro-react-native-babel-preset/src/configs/main.js#L52), and [`@babel/plugin-transform-react-jsx-source`, etc. if it’s in dev mode](https://github.com/facebook/metro/blob/28c967c9731b66e4088c0ed835ee8d91d920dfd7/packages/metro-react-native-babel-preset/src/configs/main.js#L143-L146), which, to my knowledge, is the old way of using React development runtime.

I checked how Expo deals with this, and found out they’ve:

* [Sets `useTransformReactJSXExperimental: true` for `metro-react-native-babel-preset`](https://github.com/expo/expo/blob/sdk-50/packages/babel-preset-expo/src/index.ts#L205), which seems to not let that preset handle JSX transformation,
* And [use `@babel/preset-react` for JSX transformation](https://github.com/expo/expo/blob/sdk-50/packages/babel-preset-expo/src/index.ts#L232-L234).

So I think a minimal change for us to fix this is to set `useTransformReactJSXExperimental: true` for `metro-react-native-babel-preset` and use `@babel/plugin-transform-react-jsx` instead.