### PR TITLE
fix: syntax errors with expo packages that uses JSX in .js files

### DIFF
--- a/packages/vxrn/src/utils/getReactNativeConfig.ts
+++ b/packages/vxrn/src/utils/getReactNativeConfig.ts
@@ -63,14 +63,19 @@ export async function getReactNativeConfig(options: VXRNOptionsFilled, viteRNCli
 
       {
         name: 'treat-js-files-as-jsx',
-        async transform(code, id) {
-          if (!id.includes(`expo-status-bar`)) return null
-          // Use the exposed transform from vite, instead of directly
-          // transforming with esbuild
-          return transformWithEsbuild(code, id, {
-            loader: 'jsx',
-            jsx: 'automatic',
-          })
+        transform: {
+          order: 'pre',
+          async handler(code, id) {
+            if (!id.includes('node_modules/expo-') && !id.includes('node_modules/@expo/')) {
+              return null
+            }
+            // Use the exposed transform from vite, instead of directly
+            // transforming with esbuild
+            return transformWithEsbuild(code, id, {
+              loader: 'jsx',
+              jsx: 'automatic',
+            })
+          },
         },
       },
     ].filter(Boolean),


### PR DESCRIPTION
* Only handle Expo packages with path matches, for now.
* Use [`order: 'pre’`](https://rollupjs.org/plugin-development/#build-hooks) to make sure JSX are handled before passing the code into SWC.