### PR TITLE
fix: syntax error with zod

### DIFF
--- a/packages/vxrn/src/plugins/reactNativeCommonJsPlugin.ts
+++ b/packages/vxrn/src/plugins/reactNativeCommonJsPlugin.ts
@@ -97,11 +97,11 @@ export function reactNativeCommonJsPlugin(options: {
                           return ''
                         }
                         let out = ''
-                        if (e.ln !== e.n) {
+                        if (e.ln !== e.n && !RESERVED_WORDS.includes(e.n)) {
                           // forces the "as x" to be referenced so it gets exported
-                          out += `__ignore = typeof ${e.n} === 'undefined' ? 0 : 0;`
+                          out += `\n__ignore = typeof ${e.n} === 'undefined' ? 0 : 0;`
                         }
-                        out += `globalThis.____forceExport = ${e.ln}`
+                        out += `\nglobalThis.____forceExport = ${e.ln}`
                         return out
                       })
                       .join(';')
@@ -186,3 +186,48 @@ export function reactNativeCommonJsPlugin(options: {
     },
   }
 }
+
+/**
+ * List of reserved words in JS. From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words.
+ */
+const RESERVED_WORDS = [
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'export',
+  'extends',
+  'false',
+  'finally',
+  'for',
+  'function',
+  'if',
+  'import',
+  'in',
+  'instanceof',
+  'new',
+  'null',
+  'return',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'typeof',
+  'var',
+  'void',
+  'while',
+  'with',
+  'let',
+  'static',
+  'yield',
+  'enum',
+]


### PR DESCRIPTION
I haven't really understood what `__ignore = typeof ${e.n} === 'undefined' ? 0 : 0;` will do, but this will break things with zod as zod is exporting things with JS reserved words ([`export { enumType as enum }`](https://github.com/colinhacks/zod/blob/v3.23.8/src/types.ts#L5267)):

```
  × Expected ';', '}' or <eof>
      ╭─[/Users/.../Projects/tamagui/node_modules/zod/lib/index.mjs:4090:1]
 4090 │ globalThis.____forceExport = discriminatedUnionType;
 4091 │ __ignore = typeof effect === 'undefined' ? 0 : 0;
 4092 │ globalThis.____forceExport = effectsType;
 4093 │ __ignore = typeof enum === 'undefined' ? 0 : 0;
      · ────────┬──────── ────
      ·         ╰── This is the expression part of an expression statement
 4094 │ globalThis.____forceExport = enumType;
 4095 │ globalThis.____forceExport = functionType;
 4096 │ globalThis.____forceExport = getErrorMap;
      ╰────
```

This is a quick fix to ignore if modules are exporting things `as` reserved words. 

> `zod` did this because internally it'll do [`import * as z from ...` and `export { z }`](https://github.com/colinhacks/zod/blob/v3.23.8/src/index.ts#L1) so that users will use it like `z.enum`.