### PR TITLE
fix: ignore `@supabase/node-fetch` from RN bundle

### DIFF
--- a/packages/vxrn/src/utils/getReactNativeBundle.ts
+++ b/packages/vxrn/src/utils/getReactNativeBundle.ts
@@ -67,6 +67,16 @@ export async function getReactNativeBundle(options: VXRNOptionsFilled, viteRNCli
           )
         }
 
+        let code = outputModule.code
+
+        // A hacky way to exclude node-fetch from the bundle.
+        //
+        // Some part of Supabase SDK will import node-fetch statically (https://github.com/supabase/supabase-js/blob/v2.45.1/src/lib/fetch.ts#L2), or dynamically (https://github.com/supabase/auth-js/blob/8222ee198a0ab10570e8b4c31ffb2aeafef86392/src/lib/helpers.ts#L99), causing the node-fetch to be included in the bundle, and while imported statically it will throw a runtime error when running on React Native.
+        if (outputModule.facadeModuleId?.includes('@supabase/node-fetch')) {
+          // This should be safe since the imported '@supabase/node-fetch' will not actually be used in Supabase SDK as there's already a global `fetch` in React Native.
+          code = ''
+        }
+
         return `
 // id: ${id}
 // name: ${outputModule.name}
@@ -76,7 +86,7 @@ ___vxrnAbsoluteToRelative___["${outputModule.facadeModuleId}"] = "${id}"
 ___modules___["${id}"] = ((exports, module) => {
 const require = createRequire("${id}", ${JSON.stringify(importsMap, null, 2)})
 
-${outputModule.code}
+${code}
 })
 
 ${


### PR DESCRIPTION
Fixes this kind of error on React Native with Supabase SDK:

```
🪵 [error] Error running module: "@supabase/node-fetch/lib/index.js"
Cannot read property 'prototype' of undefined
TypeError: Cannot read property 'prototype' of undefined
    at anonymous (http://127.0.0.1:8081/index.bundle?platform=ios&dev=true&hot=false&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:107110:64)
    at module252 (http://127.0.0.1:8081/index.bundle?platform=ios&dev=true&hot=false&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:107556:3)
    at __getRequire (http://127.0.0.1:8081/index.bundle?platform=ios&dev=true&hot=false&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:56:18)
    at require (http://127.0.0.1:8081/index.bundle?platform=ios&dev=true&hot=false&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:105:33)
    at module148 (http://127.0.0.1:8081/index.bundle?platform=ios&dev=true&hot=false&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:90957:22)
    at __getRequire (http://127.0.0.1:8081/index.bundle?platform=ios&dev=true&hot=false&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:56:18)
```

## Why importing `@supabase/node-fetch` will cause runtime error?

`node-fetch` is meant to be run on Node.js and it will [access globals that will be undefined such as `Stream.Readable`](https://github.com/supabase/node-fetch/blob/bd8f50a4ae647e56cda296b8301d7dff01d4a87b/src/request.js#L44) under a RN runtime.

## Who is trying to import `@supabase/node-fetch`?

Supabase SDK defines functions called `resolveFetch` that are responsible to return a suitable `fetch` function for the current environment.

Each Supabase package has their own `resolveFetch` function implementation.

While some packages uses [dynamic import to load `@supabase/node-fetch` only if it’s needed](https://github.com/supabase/auth-js/blob/8222ee198a0ab10570e8b4c31ffb2aeafef86392/src/lib/helpers.ts#L93-L104) (such as `@supabase/auth-js`), there’re some that imports `@supabase/node-fetch` statically - namely [`@supabase/supabase-js`](https://github.com/supabase/supabase-js/blob/v2.45.1/src/lib/fetch.ts#L6-L16) and [`@supabase/postgrest-js`](https://github.com/supabase/postgrest-js/blob/master/src/PostgrestBuilder.ts#L2) as we encountered.

## Future work

* Find out why this does not cause error with Metro bundler.
* Maybe send PRs to Supabase to use dynamic import.
  * But still we might want to find a way to exclude those unused `node-fetch` code from the bundle.
