### PR TITLE
fix(rn): avoid "failed to read input source map: failed to parse inline source map url" errors on certain packages

### DIFF
--- a/packages/vxrn/src/utils/getReactNativeConfig.ts
+++ b/packages/vxrn/src/utils/getReactNativeConfig.ts
@@ -56,6 +56,26 @@ export async function getReactNativeConfig(options: VXRNOptionsFilled, viteRNCli
         mode: 'build',
       }),
 
+      // Avoid "failed to read input source map: failed to parse inline source map url" errors on certain packages, such as react-native-reanimated.
+      {
+        name: 'remove-inline-source-maps',
+        transform: {
+          order: 'pre',
+          async handler(code, id) {
+            if (!id.includes('react-native-reanimated')) {
+              return null
+            }
+
+            const inlineSourceMapIndex = code.lastIndexOf('//# sourceMappingURL=')
+            if (inlineSourceMapIndex >= 0) {
+              return code.slice(0, inlineSourceMapIndex).trimEnd();
+            }
+
+            return null;
+          },
+        },
+      },
+
       viteNativeSWC({
         tsDecorators: true,
         mode: 'build',


### PR DESCRIPTION
Some packages such as `react-native-reanimated` will cause `getReactNativeBundle` to stuck with errors, this is an example:

```
transforming (1767) ../core/theme/dist/esm/_mutateTheme.native.js  ERROR  failed to read input source map: failed to parse inline source map url
index.js.map

Caused by:
    relative URL without a base
    at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/swc-0.278.2/src/lib.rs:407

transforming (1959) ../core/web/dist/esm/_withStableStyle.native.js  ERROR  failed to read input source map: failed to parse inline source map url
index.js.map

Caused by:
    relative URL without a base
    at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/swc-0.278.2/src/lib.rs:407

  ERROR  failed to read input source map: failed to parse inline source map url
index.js.map

Caused by:
    relative URL without a base
    at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/swc-0.278.2/src/lib.rs:407

  ERROR  failed to read input source map: failed to parse inline source map url
index.js.map

Caused by:
    relative URL without a base
    at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/swc-0.278.2/src/lib.rs:407

```

I think it's because they are using inline source map URLs like this:

```js
//# sourceMappingURL=Animated.js.map
```

instead of

```js
//# sourceMappingURL=./Animated.js.map
```

This is a hack to avoid that while we find a proper fix.