### PR TITLE
fix(rn): export some name exports of RN internals

### DIFF
--- a/packages/vxrn/src/utils/swapPrebuiltReactModules.ts
+++ b/packages/vxrn/src/utils/swapPrebuiltReactModules.ts
@@ -141,6 +141,17 @@ export async function swapPrebuiltReactModules(cacheDir: string): Promise<Plugin
         let out = `const ___val = __cachedModules["${idOut}"]
         const ___defaultVal = ___val ? ___val.default || ___val : ___val
         export default ___defaultVal`
+
+        // Some packages such as react-native-gesture-handler are importing from react-native internals with named imports.
+        // TODO: This is a workaround to handle it case by case.
+        if (id.includes('react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry')) {
+          out += '\nexport const customBubblingEventTypes = ___val.customBubblingEventTypes'
+          out += '\nexport const customDirectEventTypes = ___val.customDirectEventTypes'
+        }
+        if (id.includes('react-native/Libraries/Pressability/PressabilityDebug')) {
+          out += '\nexport const PressabilityDebugView = ___val.PressabilityDebugView'
+        }
+
         return out
       }
 


### PR DESCRIPTION
Some packages, such as react-native-gesture-handler, are importing from react-native internals with named imports.

* [`PressabilityDebugView`](https://github.com/software-mansion/react-native-gesture-handler/blob/2.18.1/src/handlers/PressabilityDebugView.tsx#L2)
* [`customDirectEventTypes`](https://github.com/software-mansion/react-native-gesture-handler/blob/2.18.1/src/handlers/customDirectEventTypes.ts#L2), [usage](https://github.com/software-mansion/react-native-gesture-handler/blob/2.18.1/src/handlers/createHandler.tsx#L8).

This is a workaround to handle it case by case.

