### PR TITLE
Fix errors when RN HMR files that uses reanimated

### DIFF
--- a/packages/vite-native-swc/src/index.ts
+++ b/packages/vite-native-swc/src/index.ts
@@ -278,7 +278,7 @@ export const transformWithOptions = async (
         module: {
           type: 'commonjs',
           strict: true,
-          importInterop: 'node',
+          importInterop: 'none', // We want SWC to transform imports to require since there's no Rollup to handle them afterwards, but without adding any interop helpers that would break with our RN module system
         },
       }),
       jsc: {

--- a/packages/vxrn/src/utils/getBaseViteConfig.ts
+++ b/packages/vxrn/src/utils/getBaseViteConfig.ts
@@ -26,18 +26,21 @@ export function getBaseViteConfig({ mode }: { mode: 'development' | 'production'
         name: 'platform-specific-resolve',
         config() {
           return {
-            resolve: {
-              extensions: webExtensions,
-              conditions: ['vxrn-web'],
-            },
-
             ssr: {
               resolve: {
+                extensions: webExtensions,
                 externalConditions: ['vxrn-web'],
               },
             },
 
             environments: {
+              client: {
+                resolve: {
+                  extensions: webExtensions,
+                  conditions: ['vxrn-web'],
+                },
+              },
+
               ios: {
                 resolve: {
                   extensions: iosExtensions,


### PR DESCRIPTION
## Repro

`examples/expo-reanimated`, run the app on native then edit `src/App.jsx`. After HMR a runtime error will occur:

```
🪵 [error] Module not found "/Users/z/Projects/vxrn/examples/expo-reanimated/node_modules/react-native-reanimated/lib/module/index.web.js" imported by "/src/App.jsx"
In importsMap:

{
  "react/jsx-dev-runtime": "react/jsx-dev-runtime",
  "react-native": "react-native",
  "/Users/z/Projects/vxrn/examples/expo-reanimated/node_modules/react-native-reanimated/lib/module/index.web.js": "/Users/z/Projects/vxrn/examples/expo-reanimated/node_modules/react-native-reanimated/lib/module/index.web.js"
}

🪵 [error] TypeError: 0, _indexweb.useSharedValue is not a function (it is undefined)

This error is located at:
    in App
    in RCTView (created by View)
    in View (created by AppContainer2)
    in RCTView (created by View)
    in View (created by AppContainer2)
    in AppContainer2
    in main(RootComponent), js engine: hermes
```

after fixing this, there's a second error:

```
🪵 [error] Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.

Check the render method of `App`.
```

## Root Cause

1. When HMR, the transpiled code is trying to load `react-native-reanimated` from `index.web.js` instead of `index.js`.
    * Seems that default `resolve.extensions` config is affecting environment specific config with the default `resolve.extensions` prepended to `environments.ios.resolve.extensions` in the resolved Vite config (`server.config.environments.ios.resolve.extensions`).
2. `Animated.View` is undefined within the HMR update.
    * SWC with module config `importInterop: 'node'` will insert interop helpers such as `_interop_require_wildcard`, which does not seems to be necessary with VXRN's RN module system and will cause errors as it [adds another level of `{ default: ... }`](https://github.com/swc-project/swc/blob/v1.7.22/packages/helpers/esm/_interop_require_wildcard.js#L13), making `Animated.View` undefined since it'll become `Animated.default.View`.


