### PR TITLE
Cache to disk

### DIFF
--- a/packages/vxrn/src/exports/dev.ts
+++ b/packages/vxrn/src/exports/dev.ts
@@ -26,6 +26,7 @@ import { getViteServerConfig } from '../utils/getViteServerConfig'
 import { hotUpdateCache } from '../utils/hotUpdateCache'
 import { applyBuiltInPatches } from '../utils/patches'
 import { clean } from './clean'
+import { join } from 'node:path'
 
 const { ensureDir } = FSExtra
 
@@ -115,10 +116,24 @@ export const dev = async (optionsIn: VXRNOptions & { clean?: boolean }) => {
   )
 
   let cachedReactNativeBundle: string | null = null
+  const reactNativeBundleCacheFile = join(
+    options.cacheDir,
+    `rn-cached-bundle-${'ios' /* TODO */}.js`
+  )
   // builds the dev initial bundle for react native
   const rnBundleHandler = defineEventHandler(async (e) => {
     try {
       const bundle = await (async () => {
+        if (!cachedReactNativeBundle && process.env.UNSTABLE_BUNDLE_CACHE) {
+          try {
+            if (await FSExtra.pathExists(reactNativeBundleCacheFile)) {
+              cachedReactNativeBundle = await FSExtra.readFile(reactNativeBundleCacheFile, 'utf-8')
+            }
+          } catch (e) {
+            console.error(`Error loading cache from ${reactNativeBundleCacheFile}: ${e}`)
+          }
+        }
+
         if (cachedReactNativeBundle) {
           console.info('Serving React Native bundle from cache')
           return cachedReactNativeBundle
@@ -126,6 +141,17 @@ export const dev = async (optionsIn: VXRNOptions & { clean?: boolean }) => {
 
         const builtBundle = await getReactNativeBundle(options, viteRNClientPlugin)
         cachedReactNativeBundle = builtBundle
+        if (process.env.UNSTABLE_BUNDLE_CACHE) {
+          // do not await cache write
+          ;(async () => {
+            try {
+              await FSExtra.writeFile(reactNativeBundleCacheFile, builtBundle)
+            } catch (e) {
+              console.error(`Error saving cache to ${reactNativeBundleCacheFile}: ${e}`)
+            }
+          })()
+        }
+
         return builtBundle
       })()
 


### PR DESCRIPTION
Write/read Rollup cache on disk.

To enable `UNSTABLE_BUNDLE_CACHE`, `export UNSTABLE_BUNDLE_CACHE=true`. If enabled, we will also read the cached bundle from disk.