### PR TITLE
fix(vxrn): swc panic with “called `Option::unwrap()` on a `None` value”

### DIFF
--- a/packages/vite-native-swc/src/index.ts
+++ b/packages/vite-native-swc/src/index.ts
@@ -63,7 +63,12 @@ const SWC_ENV = {
   },
   include: [],
   // this breaks the uniswap app for any file with a ...spread
-  exclude: ['transform-spread', 'transform-destructuring', 'transform-object-rest-spread'],
+  exclude: [
+    'transform-spread',
+    'transform-destructuring',
+    'transform-object-rest-spread',
+    'transform-async-to-generator', // `transform-async-to-generator` is relying on `transform-destructuring`. If we exclude `transform-destructuring` but not `transform-async-to-generator`, the SWC binary will panic with error: `called `Option::unwrap()` on a `None` value`. See: https://github.com/swc-project/swc/blob/v1.7.14/crates/swc_ecma_compat_es2015/src/generator.rs#L703-L705
+  ],
 }
 
 function getParser(id: string, forceJSX = false) {


### PR DESCRIPTION
Initially, I just wanted to suppress the error message printed to the terminal.

The error message is printed while SWC [calls its native bindings `bindings.transform()`](https://github.com/swc-project/swc/blob/v1.7.14/packages/core/src/index.ts#L231-L235), where the native bindings are imported from SWC binaries, on macOS it's `@swc/core-darwin-arm64/swc.darwin-arm64.node`.

Tried many tricky attempts like `process.stdout.write`, but those errors still print. I do not quite understand since wrapping the `bindings.transform()` in a try-catch won't work as expected too, it seems the cache cause will not be reached, but an error is still thrown.

Looked into the Rust code where the error might occur and finally discovered that we can just prevent that error from happening in the first place 😂

Ref: https://github.com/swc-project/swc/blob/v1.7.14/crates/swc_ecma_compat_es2015/src/generator.rs#L703-L705