### PR TITLE
fix(vite): Properly reject errors from userland API routes

### DIFF
--- a/packages/vxs/src/vite/resolveAPIRequest.ts
+++ b/packages/vxs/src/vite/resolveAPIRequest.ts
@@ -5,7 +5,6 @@ export function resolveAPIRequest(asyncImport: () => Promise<any>, request: Requ
   if (!asyncImport) return
 
   return new Promise((res, rej) => {
-    // Added rejection handler
     const id = { _id: Math.random() }
     requestAsyncLocalStore.run(id, async () => {
       try {
@@ -55,7 +54,7 @@ export function resolveAPIRequest(asyncImport: () => Promise<any>, request: Requ
         if (isResponse(err)) {
           res(err)
         } else {
-          rej(err) // Reject the promise on error
+          rej(err) // reject the promise on any other error
         }
       }
     })

--- a/packages/vxs/src/vite/resolveAPIRequest.ts
+++ b/packages/vxs/src/vite/resolveAPIRequest.ts
@@ -4,7 +4,8 @@ import { asyncHeadersCache, mergeHeaders, requestAsyncLocalStore } from './heade
 export function resolveAPIRequest(asyncImport: () => Promise<any>, request: Request) {
   if (!asyncImport) return
 
-  return new Promise((res) => {
+  return new Promise((res, rej) => {
+    // Added rejection handler
     const id = { _id: Math.random() }
     requestAsyncLocalStore.run(id, async () => {
       try {
@@ -54,7 +55,7 @@ export function resolveAPIRequest(asyncImport: () => Promise<any>, request: Requ
         if (isResponse(err)) {
           res(err)
         } else {
-          throw err
+          rej(err) // Reject the promise on error
         }
       }
     })


### PR DESCRIPTION
Fix for API routes hanging when an error is thrown from user-land +api.ts routes.

- Added rejection handler to the promise in resolveAPIRequest function
- Modified error handling to reject the promise on error

Implementation reason: Ensures that errors from userland API routes are properly handled and propagated, improving error management and debugging.

Files changed:
- packages/vxs/src/vite/resolveAPIRequest.ts