### PR TITLE
fix: "EISDIR: illegal operation on a directory, read" when importing a file while there’s a dir with the same name

### DIFF
--- a/packages/vxrn/src/utils/getReactNativeConfig.ts
+++ b/packages/vxrn/src/utils/getReactNativeConfig.ts
@@ -45,20 +45,26 @@ export async function getReactNativeConfig(options: VXRNOptionsFilled, viteRNCli
           if (importer?.includes('node_modules')) {
             return
           }
+          /** Should be 'ios' or 'android' */
+          const environmentName = this.environment.name
           try {
             const resolved = join(dirname(importer), importee)
             if ((await stat(resolved)).isDirectory()) {
               // fix for importing a directory
               // TODO this would probably want to support their configured extensions
-              // TODO also platform-specific extensions
-              for (const ext of ['ts', 'tsx', 'js']) {
-                try {
-                  const withExt = join(resolved, `index.${ext}`)
-                  await stat(withExt)
-                  // its a match
-                  return withExt
-                } catch {
-                  // keep going
+              for (const ext of ['ts', 'tsx', 'js', 'jsx']) {
+                for (const platformExt of [environmentName, 'native', null]) {
+                  try {
+                    const withExt = join(
+                      resolved,
+                      ['index', platformExt, ext].filter(Boolean).join('.')
+                    )
+                    await stat(withExt)
+                    // its a match
+                    return withExt
+                  } catch {
+                    // keep going
+                  }
                 }
               }
             }

--- a/packages/vxrn/src/utils/state.ts
+++ b/packages/vxrn/src/utils/state.ts
@@ -15,5 +15,6 @@ export async function readState(cacheDir: string) {
 
 export async function writeState(cacheDir: string, state: State) {
   const statePath = join(cacheDir, 'state.json')
+  await FSExtra.ensureDir(cacheDir)
   await FSExtra.writeJSON(statePath, state)
 }

--- a/packages/vxrn/src/utils/swapPrebuiltReactModules.ts
+++ b/packages/vxrn/src/utils/swapPrebuiltReactModules.ts
@@ -149,43 +149,6 @@ export async function swapPrebuiltReactModules(
           return info.alias
         }
       }
-
-      // TODO this also shouldnt be here
-      // TODO this is terrible and slow, we should be able to get extensions working:
-      // having trouble getting .native.js to be picked up via vite
-      // tried adding packages to optimizeDeps, tried resolveExtensions + extensions...
-      // tried this but seems to not be called for node_modules
-      if (isBuildingNativeBundle) {
-        if (id[0] === '.') {
-          const absolutePath = resolve(dirname(importer), id)
-          const nativePath = absolutePath.replace(/(.m?js)/, '.native.js')
-          if (nativePath === id) return
-
-          // // if exists can skip
-          // if (await FSExtra.pathExists(absolutePath)) {
-          //   return
-          // }
-
-          try {
-            const directoryPath = absolutePath + '/index.native.js'
-            const directoryNonNativePath = absolutePath + '/index.js'
-            if (await FSExtra.pathExists(directoryPath)) {
-              return directoryPath
-            }
-            if (await FSExtra.pathExists(directoryNonNativePath)) {
-              return directoryNonNativePath
-            }
-            if (
-              (await FSExtra.pathExists(nativePath)) &&
-              (await FSExtra.stat(nativePath)).isFile() // Prevents "EISDIR: illegal operation on a directory, read" errors
-            ) {
-              return nativePath
-            }
-          } catch (err) {
-            console.warn(`error probably fine`, err)
-          }
-        }
-      }
     },
 
     async load(id) {

--- a/packages/vxrn/src/utils/swapPrebuiltReactModules.ts
+++ b/packages/vxrn/src/utils/swapPrebuiltReactModules.ts
@@ -175,7 +175,10 @@ export async function swapPrebuiltReactModules(
             if (await FSExtra.pathExists(directoryNonNativePath)) {
               return directoryNonNativePath
             }
-            if (await FSExtra.pathExists(nativePath)) {
+            if (
+              (await FSExtra.pathExists(nativePath)) &&
+              (await FSExtra.stat(nativePath)).isFile() // Prevents "EISDIR: illegal operation on a directory, read" errors
+            ) {
               return nativePath
             }
           } catch (err) {


### PR DESCRIPTION
I don't think the `if (isBuildingNativeBundle) {` logic in `swapPrebuiltReactModules.ts` is necessary now since we have Vite handling platform-specific extensions now I think. So I ended up removing it, tested it on a basic example, and it seems to be working well. If not, we should skip the last commit that removes it.