### PR TITLE
fix: quick nav anchor links not scrolling to correct section

### DIFF
--- a/apps/onestack.dev/features/docs/DocsRightSidebar.tsx
+++ b/apps/onestack.dev/features/docs/DocsRightSidebar.tsx
@@ -60,7 +60,7 @@ export function DocsRightSidebar({ headings = [] }: { headings: Frontmatter['hea
                   return (
                     <XStack key={i} tag="li" ai="center" py="$2">
                       {priority > 2 && <Circle size={4} mx="$2" />}
-                      <QuickNavLink href={id}>{title}</QuickNavLink>
+                      <QuickNavLink href={`#${id}`}>{title}</QuickNavLink>
                     </XStack>
                   )
                 })}

--- a/packages/mdx/src/getHeadings.ts
+++ b/packages/mdx/src/getHeadings.ts
@@ -7,5 +7,5 @@ export const getHeadings = (source: string) =>
     .map((x) => ({
       title: getTitle(x),
       priority: x.trim().split(' ')[0].length,
-      id: `#${getTitle(x).replace(/\s+/g, '-').toLowerCase()}`,
+      id: getTitle(x).replace(/\s+/g, '-').toLowerCase(),
     }))


### PR DESCRIPTION
This PR fixes the issue where clicking the quick nav anchor links was not scrolling to correct section

Before fix:

https://github.com/user-attachments/assets/22e3c872-5ed1-490e-88e6-52a592e12928

After fix:

https://github.com/user-attachments/assets/5037c3be-e2bd-40a7-94a3-55391a8e56e5

