### PR TITLE
fix: change destination link for matias' name

### DIFF
--- a/apps/onestack.dev/data/docs/introduction.mdx
+++ b/apps/onestack.dev/data/docs/introduction.mdx
@@ -50,7 +50,7 @@ One was built thanks to some amazing open source technologies and contributors:
 
 And a special thanks to the following individuals:
 
-- [Matias Capeletto](https://x.com/patak_dev) for inviting us to speak at ViteConf, giving the initial spark.
+- [Matias Capeletto](https://github.com/patak-dev) for inviting us to speak at ViteConf, giving the initial spark.
 - [Fatih Aygün](https://github.com/cyco130) for freely helping at length, getting us past many hurdles.
 - [Hiroshi Ogawa](https://github.com/hi-ogawa) for his expert consulting for which One wouldn't exist without.
 - Dan Maier, for graciously gifting us the `one` npm package.


### PR DESCRIPTION
This PR changes the link of Matias Capeletto from X which leads no where to his Github like others on the same page