### PR TITLE
fix(docs): update docs to reflect react 19 support for native

### DIFF
--- a/apps/onestack.dev/data/docs/features.mdx
+++ b/apps/onestack.dev/data/docs/features.mdx
@@ -15,7 +15,7 @@ Out of the box, the One Vite plugin does the following:
 - Generates [types for routes](/docs/routing#types) and updates them when routes change
 - Enables [loaders](/docs/routing-loader) and tree shakes them out on client. Using the amazing [babel-dead-code-elimination](https://github.com/pcattori/babel-dead-code-elimination) module
 - Enables the [`deps` option](/docs/configuration#deps) that allows for easy node_module patching
-- Swaps between React 18 for native and React 19 for web
+- Uses React 19 for both native and web
 - Adds [vite-tsconfig-paths](https://github.com/aleclarson/vite-tsconfig-paths) plugin, unless it detects you've added it already
 - Loads `.env` file into `process.env` before running anything using [dotenv](https://www.npmjs.com/package/dotenv)
 - Adds a well-configured `tsconfig.json` if it doesn't exist


### PR DESCRIPTION
This PR updates the docs to reflect that native now supports React 19 as confirmed by the default one app started with `npx one` below

<img width="927" height="795" alt="Screenshot 2025-12-29 at 11 52 42 PM" src="https://github.com/user-attachments/assets/731e817d-9d1a-48b7-b8c4-941eaf4fea89" />


