### PR TITLE
fix: graceful handling of missing loader files during preload

### DIFF
--- a/packages/one/src/router/router.ts
+++ b/packages/one/src/router/router.ts
@@ -388,7 +388,7 @@ async function doPreload(href: string) {
     const [_preload, cssPreloadModule, loader] = await Promise.all([
       dynamicImport(preloadPath),
       dynamicImport(cssPreloadPath)?.catch(() => null) ?? Promise.resolve(null), // graceful fail if no CSS preload
-      dynamicImport(loaderPath),
+      dynamicImport(loaderPath)?.catch(() => null) ?? Promise.resolve(null), // graceful fail if no loader file
       preloadRouteModules(href),
     ])
 


### PR DESCRIPTION
## Summary
- Fixes 404 errors when preloading routes that don't have a `loader` export
- Routes without `loader` don't generate `_vxrn_loader.js` files, but client was still trying to import them
- Now gracefully catches the error (matching CSS preload behavior)

Fixes #506

## Test plan
- [ ] Create a route without a loader export
- [ ] Navigate to that route - should not see 404 errors in console