### PR TITLE
fix: preserve type-only imports during client tree shaking

### DIFF
--- a/packages/one/src/vite/plugins/clientTreeShakePlugin.test.ts
+++ b/packages/one/src/vite/plugins/clientTreeShakePlugin.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import { transformTreeShakeClient } from './clientTreeShakePlugin'
+
+describe('transformTreeShakeClient', () => {
+  it('should remove loader function and unused imports', async () => {
+    const code = `
+import { db } from 'server-only-db'
+
+export function loader() {
+  return db.query()
+}
+
+export default function Page() {
+  return <div>Hello</div>
+}
+`
+    const result = await transformTreeShakeClient(code, 'test.tsx')
+    expect(result).toBeDefined()
+    expect(result?.code).not.toContain('server-only-db')
+    expect(result?.code).toContain('export default function Page')
+    expect(result?.code).toContain('export function loader()')
+  })
+
+  it('should preserve type-only imports after dead code elimination', async () => {
+    const code = `
+import type { LoaderProps } from 'one'
+import { db } from 'server-only-db'
+
+export function loader(props: LoaderProps) {
+  return db.query()
+}
+
+export default function Page() {
+  return <div>Hello</div>
+}
+`
+    const result = await transformTreeShakeClient(code, 'test.tsx')
+    expect(result).toBeDefined()
+    // Type-only import should be preserved
+    expect(result?.code).toContain("import type { LoaderProps } from 'one'")
+    // Server-only import should be removed
+    expect(result?.code).not.toContain('server-only-db')
+    // Component should be preserved
+    expect(result?.code).toContain('export default function Page')
+  })
+
+  it('should preserve multiple type-only imports', async () => {
+    const code = `
+import type { LoaderProps, RouteInfo } from 'one'
+import type { ServerType } from './server-types'
+import { serverUtil } from './server-utils'
+
+export function loader(props: LoaderProps): RouteInfo {
+  return serverUtil()
+}
+
+export default function Page() {
+  return <div>Hello</div>
+}
+`
+    const result = await transformTreeShakeClient(code, 'test.tsx')
+    expect(result).toBeDefined()
+    // Both type-only imports should be preserved
+    expect(result?.code).toContain("import type { LoaderProps, RouteInfo } from 'one'")
+    expect(result?.code).toContain("import type { ServerType } from './server-types'")
+    // Server utility import should be removed
+    expect(result?.code).not.toContain('server-utils')
+  })
+
+  it('should not modify code without loader or generateStaticParams', async () => {
+    const code = `
+import type { SomeType } from 'some-module'
+
+export default function Page() {
+  return <div>Hello</div>
+}
+`
+    const result = await transformTreeShakeClient(code, 'test.tsx')
+    // Should return undefined since no transformation is needed
+    expect(result).toBeUndefined()
+  })
+
+  it('should remove generateStaticParams and preserve type imports', async () => {
+    const code = `
+import type { Params } from 'one'
+import { getItems } from './server-data'
+
+export function generateStaticParams(): Params[] {
+  return getItems().map(item => ({ id: item.id }))
+}
+
+export default function Page() {
+  return <div>Hello</div>
+}
+`
+    const result = await transformTreeShakeClient(code, 'test.tsx')
+    expect(result).toBeDefined()
+    // Type import should be preserved
+    expect(result?.code).toContain("import type { Params } from 'one'")
+    // Server data import should be removed
+    expect(result?.code).not.toContain('server-data')
+    // Empty generateStaticParams should be added back
+    expect(result?.code).toContain('export function generateStaticParams() {}')
+  })
+})

--- a/packages/one/src/vite/plugins/clientTreeShakePlugin.ts
+++ b/packages/one/src/vite/plugins/clientTreeShakePlugin.ts
@@ -7,8 +7,8 @@ import { deadCodeElimination, findReferencedIdentifiers } from 'babel-dead-code-
 import type { Plugin } from 'vite'
 import { EMPTY_LOADER_STRING } from '../constants'
 
-const traverse = BabelTraverse['default'] as typeof BabelTraverse
-const generate = BabelGenerate['default'] as any as typeof BabelGenerate
+const traverse = (BabelTraverse['default'] || BabelTraverse) as typeof BabelTraverse
+const generate = (BabelGenerate['default'] || BabelGenerate) as any as typeof BabelGenerate
 
 // Collect type-only imports before dead code elimination runs
 // These should never be removed since TypeScript erases them at compile time


### PR DESCRIPTION
## Summary
- Fixes type-only imports being incorrectly removed during client tree shaking
- `import type { X } from './server-module'` should be preserved since TypeScript erases types at compile time
- This enables tRPC and other patterns where types are imported from server-only modules

Fixes #363

## Changes
- Added `collectTypeImports()` to capture all type-only import declarations before dead code elimination
- Added `restoreTypeImports()` to restore any that were incorrectly removed
- Type imports (`importKind === 'type'`) are now preserved through the tree shaking process

## Test plan
- [ ] Create a server-only module that exports types
- [ ] Import those types in a client component using `import type { X } from '...'`
- [ ] Verify no errors about server-only modules being imported in client components