### PR TITLE
fix(blog): link to Pokai's github correctly

### DIFF
--- a/apps/onestack.dev/data/blog/version-one-rc1.mdx
+++ b/apps/onestack.dev/data/blog/version-one-rc1.mdx
@@ -52,7 +52,7 @@ Pick a starter and you're up and running. From there, check out the [introductio
 
 One started as a fork of [Expo Router](https://expo.dev/router), built on top of [vxrn](https://vxrn.dev). Thank you to the Expo team for their incredible work.
 
-A huge thank you to [Pokai Chang](https://github.com/pockiiie), who did the vast majority of the work bringing One to v1. From countless bug fixes to major features, Pokai has been instrumental in making One what it is today.
+A huge thank you to [Pokai Chang](https://github.com/zetavg), who did the vast majority of the work bringing One to v1. From countless bug fixes to major features, Pokai has been instrumental in making One what it is today.
 
 Thanks also to [Quan Nguyen](https://github.com/anhquan291) for helping out along the way. And to those who helped get One off the ground: [Fatih Aygün](https://github.com/cyco130), [Hiroshi Ogawa](https://github.com/hi-ogawa), [Matias Capeletto](https://github.com/patak-dev), and Dan Maier (for the `one` package name).
 


### PR DESCRIPTION
This PR makes sure to link to Pokai's github correctly