### PR TITLE
fix(useBlocker): support blocking navigation via Link component

### DIFF
--- a/packages/one/src/router/router.ts
+++ b/packages/one/src/router/router.ts
@@ -46,6 +46,7 @@ import {
   RouteValidationError,
   ParamValidationError,
 } from '../validateParams'
+import { checkBlocker } from '../useBlocker'
 
 // Module-scoped variables
 export let routeNode: RouteNode | null = null
@@ -634,6 +635,11 @@ export async function linkTo(
 
   if (shouldLinkExternally(href)) {
     openExternalURL(href)
+    return
+  }
+
+  // Check if any blocker wants to block this navigation (web only)
+  if (checkBlocker(href, event === 'REPLACE' ? 'replace' : 'push')) {
     return
   }
 

--- a/packages/one/src/useBlocker.native.ts
+++ b/packages/one/src/useBlocker.native.ts
@@ -140,3 +140,14 @@ export function useBlocker(shouldBlock: BlockerFunction | boolean): Blocker {
     location: blockedLocation!,
   }
 }
+
+/**
+ * No-op on native - native uses React Navigation's beforeRemove event instead.
+ * This is only used by the router on web.
+ */
+export function checkBlocker(
+  _nextLocation: string,
+  _historyAction: 'push' | 'pop' | 'replace' = 'push'
+): boolean {
+  return false
+}

--- a/packages/one/src/useBlocker.ts
+++ b/packages/one/src/useBlocker.ts
@@ -305,3 +305,36 @@ export function useBlocker(shouldBlock: BlockerFunction | boolean): Blocker {
     location: blockedLocation!,
   }
 }
+
+/**
+ * Check if any active blocker wants to block navigation.
+ * Called by the router before navigating via Link.
+ * Returns true if navigation was blocked.
+ */
+export function checkBlocker(
+  nextLocation: string,
+  historyAction: 'push' | 'pop' | 'replace' = 'push'
+): boolean {
+  if (Platform.OS !== 'web' || typeof window === 'undefined') {
+    return false
+  }
+
+  if (isProceeding) {
+    return false
+  }
+
+  for (const [, callbacks] of blockerCallbacks) {
+    if (callbacks.shouldBlock()) {
+      isBlocking = true
+      pendingNavigation = {
+        previousLocation: currentLocation,
+        nextLocation,
+        historyAction,
+      }
+      callbacks.onBlock(pendingNavigation)
+      return true
+    }
+  }
+
+  return false
+}

--- a/packages/one/types/index.d.ts
+++ b/packages/one/types/index.d.ts
@@ -55,7 +55,7 @@ export * as routerStore from './router/router';
 export { useNavigation } from './router/useNavigation';
 export { registerPreloadedRoute } from './router/useViteRoutes';
 export type { Endpoint, LoaderProps } from './types';
-export { useBlocker, type Blocker, type BlockerFunction, type BlockerState } from './useBlocker';
+export { useBlocker, type Blocker, type BlockerFunction, type BlockerState, } from './useBlocker';
 export { validateParams, zodParamValidator, ParamValidationError, RouteValidationError, type ParamValidator, type InferParamInput, type InferParamOutput, type ValidateRouteProps, type ValidationResult, type RouteValidationFn, } from './validateParams';
 export { useValidationState, type ValidationState } from './router/router';
 export { useFocusEffect } from './useFocusEffect';

--- a/packages/one/types/useBlocker.d.ts
+++ b/packages/one/types/useBlocker.d.ts
@@ -63,4 +63,10 @@ export type Blocker = {
  * ```
  */
 export declare function useBlocker(shouldBlock: BlockerFunction | boolean): Blocker;
+/**
+ * Check if any active blocker wants to block navigation.
+ * Called by the router before navigating via Link.
+ * Returns true if navigation was blocked.
+ */
+export declare function checkBlocker(nextLocation: string, historyAction?: 'push' | 'pop' | 'replace'): boolean;
 //# sourceMappingURL=useBlocker.d.ts.map

--- a/packages/one/types/useBlocker.native.d.ts
+++ b/packages/one/types/useBlocker.native.d.ts
@@ -52,4 +52,9 @@ export type Blocker = {
  * ```
  */
 export declare function useBlocker(shouldBlock: BlockerFunction | boolean): Blocker;
+/**
+ * No-op on native - native uses React Navigation's beforeRemove event instead.
+ * This is only used by the router on web.
+ */
+export declare function checkBlocker(_nextLocation: string, _historyAction?: 'push' | 'pop' | 'replace'): boolean;
 //# sourceMappingURL=useBlocker.native.d.ts.map


### PR DESCRIPTION
This PR makes sure the new blocker works for the `<Link/>` component imported from One and not only browser history apis.