### PR TITLE
Fix spelling error in version-one-rc1.mdx

### DIFF
--- a/apps/onestack.dev/data/blog/version-one-rc1.mdx
+++ b/apps/onestack.dev/data/blog/version-one-rc1.mdx
@@ -20,7 +20,7 @@ Thanks to a lot of investment, we've achieved something remarkable: **stability*
 
 Thanks to render modes and a variety of optimizations, One makes it possible for the first time to **get 100 on your Lighthouse performance score, even while sharing nearly all your code with native**.
 
-One is **a uniquely great framework even if you are only targeting web**. In a world haunted by complexity, One punches above it's weight by _focusing_: it only supports React, no RSC or magic directives. It's comprenesive, with a featureset besting many modern web frameworks, and the benefit of new, clean codebase targeting modern versions.
+One is **a uniquely great framework even if you are only targeting web**. In a world haunted by complexity, One punches above it's weight by _focusing_: it only supports React, no RSC or magic directives. It's comprehensive, with a featureset besting many modern web frameworks, and the benefit of new, clean codebase targeting modern versions.
 
 Some highlights:
 


### PR DESCRIPTION
I was just sneaking a peek at the RC1 announcement and noticed a typo.