### PR TITLE
Fix Metro Mode documentation URL in status page

### DIFF
--- a/apps/onestack.dev/data/docs/status.mdx
+++ b/apps/onestack.dev/data/docs/status.mdx
@@ -37,7 +37,7 @@ Web is production ready.
 
 ### Native <Status is="stable" />
 
-Native is stable in [Metro mode](/docs/native-metro-mode).
+Native is stable in [Metro mode](/docs/metro-mode).
 
 - Local development <Status is="stable" />
 - Production builds <Status is="stable" />


### PR DESCRIPTION
Documentation-only PR: stumbled on this 404 while reading the docs.