### PR TITLE
fix(RouteTree): fix bg color for route tree component

### DIFF
--- a/apps/onestack.dev/features/docs/RouteTree.tsx
+++ b/apps/onestack.dev/features/docs/RouteTree.tsx
@@ -20,7 +20,7 @@ export const RouteTree = ({
   return (
     <YStack
       ov="hidden"
-      theme="light"
+      bg="$color3"
       {...(!indent && {
         bw: 2,
         borderColor: '$color4',


### PR DESCRIPTION
This PR fixes the awful look of the Route tree component in the docs 

Here's how it looked before:
<img width="778" height="333" alt="Screenshot 2026-02-06 at 9 14 45 PM" src="https://github.com/user-attachments/assets/d1594502-62cf-4477-a4b2-9a74fafd7939" />
