### PR TITLE
feat(one): unified server build mode + nested api middleware fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -844,6 +844,24 @@
         "vitest": "^4.1.0",
       },
     },
+    "tests/test-build-unified": {
+      "name": "test-build-unified",
+      "version": "1.15.10-1776565272880",
+      "dependencies": {
+        "axios": "^1.7.0",
+        "date-fns": "^3.6.0",
+        "ms": "^2.1.3",
+        "one": "workspace:*",
+        "zod": "^3.23.0",
+      },
+      "devDependencies": {
+        "@types/ms": "^0.7.34",
+        "kill-my-port": "1.1.2",
+        "typescript": "^5.7.3",
+        "vitest": "^4.1.0",
+        "wrangler": "4.60.0",
+      },
+    },
     "tests/test-cache-headers": {
       "name": "test-cache-headers",
       "version": "1.15.10-1776565272880",
@@ -2559,7 +2577,7 @@
 
     "@types/minimatch": ["@types/minimatch@3.0.5", "", {}, "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="],
 
-    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+    "@types/ms": ["@types/ms@0.7.34", "", {}, "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="],
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
 
@@ -2777,7 +2795,11 @@
 
     "async-retry": ["async-retry@1.3.1", "", { "dependencies": { "retry": "0.12.0" } }, "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
+
+    "axios": ["axios@1.15.2", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A=="],
 
     "b4a": ["b4a@1.7.3", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q=="],
 
@@ -2951,6 +2973,8 @@
 
     "colorette": ["colorette@1.4.0", "", {}, "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "command-exists": ["command-exists@1.2.9", "", {}, "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="],
@@ -3043,6 +3067,8 @@
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
 
+    "date-fns": ["date-fns@3.6.0", "", {}, "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="],
+
     "dayjs": ["dayjs@1.11.19", "", {}, "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -3070,6 +3096,8 @@
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "depcheck": ["depcheck@1.4.7", "", { "dependencies": { "@babel/parser": "^7.23.0", "@babel/traverse": "^7.23.2", "@vue/compiler-sfc": "^3.3.4", "callsite": "^1.0.0", "camelcase": "^6.3.0", "cosmiconfig": "^7.1.0", "debug": "^4.3.4", "deps-regex": "^0.2.0", "findup-sync": "^5.0.0", "ignore": "^5.2.4", "is-core-module": "^2.12.0", "js-yaml": "^3.14.1", "json5": "^2.2.3", "lodash": "^4.17.21", "minimatch": "^7.4.6", "multimatch": "^5.0.0", "please-upgrade-node": "^3.2.0", "readdirp": "^3.6.0", "require-package-name": "^2.0.1", "resolve": "^1.22.3", "resolve-from": "^5.0.0", "semver": "^7.5.4", "yargs": "^16.2.0" }, "bin": { "depcheck": "bin/depcheck.js" } }, "sha512-1lklS/bV5chOxwNKA/2XUUk/hPORp8zihZsXflr8x0kLwmcZ9Y9BsS6Hs3ssvA+2wUVbG0U2Ciqvm1SokNjPkA=="],
 
@@ -3355,6 +3383,8 @@
 
     "flow-enums-runtime": ["flow-enums-runtime@0.0.6", "", {}, "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw=="],
 
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
     "fontfaceobserver": ["fontfaceobserver@2.3.0", "", {}, "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg=="],
 
     "fontverter": ["fontverter@2.0.0", "", { "dependencies": { "wawoff2": "^2.0.0", "woff2sfnt-sfnt2woff": "^1.0.0" } }, "sha512-DFVX5hvXuhi1Jven1tbpebYTCT9XYnvx6/Z+HFUPb7ZRMCW+pj2clU9VMhoTPgWKPhAs7JJDSk3CW1jNUvKCZQ=="],
@@ -3362,6 +3392,8 @@
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "format": ["format@0.2.2", "", {}, "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="],
 
@@ -4227,7 +4259,7 @@
 
     "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
 
-    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
     "ps-list": ["ps-list@7.2.0", "", {}, "sha512-v4Bl6I3f2kJfr5o80ShABNHAokIgY+wFDTQfE+X3zWYgSGQOCBeYptLZUpoOALBqO5EawmDN/tjTldJesd0ujQ=="],
 
@@ -4634,6 +4666,8 @@
     "terser": ["terser@5.44.1", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw=="],
 
     "test-app-cases": ["test-app-cases@workspace:tests/test-app-cases"],
+
+    "test-build-unified": ["test-build-unified@workspace:tests/test-build-unified"],
 
     "test-cache-headers": ["test-cache-headers@workspace:tests/test-cache-headers"],
 
@@ -5141,6 +5175,8 @@
 
     "@tybys/wasm-util/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@types/debug/@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
     "@types/mdast/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/nlcst/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
@@ -5429,6 +5465,8 @@
 
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
+    "proxy-agent/proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
     "puppeteer/cosmiconfig": ["cosmiconfig@9.0.0", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg=="],
 
     "r-json/w-json": ["w-json@1.3.10", "", {}, "sha512-XadVyw0xE+oZ5FGApXsdswv96rOhStzKqL53uSe5UaTadABGkWIg1+DTx8kiZ/VqTZTBneoL0l65RcPe4W3ecw=="],
@@ -5546,6 +5584,8 @@
     "tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+
+    "test-build-unified/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 

--- a/examples/one-basic/vite.config.ts
+++ b/examples/one-basic/vite.config.ts
@@ -8,6 +8,16 @@ export default defineConfig({
         defaultRenderMode: 'ssg',
       },
 
+      // unified build mode — pages, api routes, and middlewares all build
+      // against the same SSR server config (same defines, same plugins, same
+      // externalization rules) and drops the blanket `ssr.noExternal: true`.
+      // this is the direction One is moving; in the next major it becomes the
+      // default and `build.api` / `build.middleware` lose their separate
+      // config surfaces.
+      build: {
+        server: { unified: true },
+      },
+
       ...(process.env.TEST_METRO && {
         native: {
           bundler: 'metro',

--- a/packages/one/src/cli/build.ts
+++ b/packages/one/src/cli/build.ts
@@ -380,13 +380,51 @@ export async function build(args: {
   const { optimizeDeps } = getOptimizeDeps('build')
   const { rolldownOptions: _rolldownOptions, ...optimizeDepsNoRolldown } = optimizeDeps
 
+  // unified mode: api + middleware routes share config with the SSR server build —
+  // same defines, plugins, externalization rules, no blanket noExternal: true.
+  // when off, keep the legacy path that derives from webBuildConfig with
+  // ssr.noExternal: true hard-coded (back-compat).
+  const serverOpts = oneOptions.build?.server
+  const isUnified =
+    typeof serverOpts === 'object' && serverOpts !== null && serverOpts.unified === true
+
   // clone plugin hooks so vite's wrapHookObject doesn't fail on reuse across builds
   // (vite defines non-configurable getters on hook objects during the first build)
-  const clonedWebBuildConfig = clonePluginHooks(vxrnOutput.webBuildConfig)
+  let baseForApi = isUnified
+    ? clonePluginHooks(vxrnOutput.serverBuildConfig ?? vxrnOutput.webBuildConfig)
+    : clonePluginHooks(vxrnOutput.webBuildConfig)
+
+  if (isUnified) {
+    // serverBuildConfig has rolldownOptions.input: ['virtual:one-entry'] —
+    // vite mergeConfig concatenates that with the api build's input object,
+    // which rolldown then tries to iterate as a string list. strip it so the
+    // per-routes input map in buildCustomRoutes takes effect cleanly.
+    //
+    // also strip `omit-api-routes`, the server's transform plugin that empties
+    // any +api / _middleware file. correct for the SSR render bundle, wrong
+    // for api/middleware builds where those files ARE the entry points.
+    const clone: InlineConfig = {
+      ...baseForApi,
+      build: baseForApi.build ? { ...baseForApi.build } : undefined,
+      plugins: baseForApi.plugins
+        ? (baseForApi.plugins as any[]).filter(
+            (p) => p && typeof p === 'object' && p.name !== 'omit-api-routes'
+          )
+        : undefined,
+    }
+    if (clone.build && (clone.build as any).rolldownOptions) {
+      const ro = { ...((clone.build as any).rolldownOptions as any) }
+      delete ro.input
+      ;(clone.build as any).rolldownOptions = ro
+    }
+    if (clone.build) {
+      delete (clone.build as any).outDir
+    }
+    baseForApi = clone
+  }
 
   const apiBuildConfig = mergeConfig(
-    // feels like this should build off the *server* build config not web
-    clonedWebBuildConfig,
+    baseForApi,
     {
       configFile: false,
       appType: 'custom',
@@ -413,19 +451,20 @@ export async function build(args: {
       appType: 'custom',
       configFile: false,
 
-      // plugins: [
-      //   nodeExternals({
-      //     exclude: optimizeDeps.include,
-      //   }) as any,
-      // ],
-
       define: vxrnOutput!.processEnvDefines,
 
-      ssr: {
-        noExternal: true,
-        external: ['react', 'react-dom'],
-        optimizeDeps: optimizeDepsNoRolldown,
-      },
+      ssr: isUnified
+        ? {
+            // in unified mode let the base (serverBuildConfig) set ssr.noExternal
+            // — default is now ['react', 'react-dom'] instead of `true`, so
+            // rolldown can externalize the rest.
+            optimizeDeps: optimizeDepsNoRolldown,
+          }
+        : {
+            noExternal: true,
+            external: ['react', 'react-dom'],
+            optimizeDeps: optimizeDepsNoRolldown,
+          },
 
       environments: {
         ssr: {
@@ -456,7 +495,10 @@ export async function build(args: {
           // prevents it from shaking out the exports
           preserveEntrySignatures: 'strict',
           input: input,
-          external: [],
+          // in unified mode, inherit externals from serverBuildConfig (user
+          // ssr.external / rolldownOptions.external). the legacy path resets
+          // them to [] so per-route files bundle everything.
+          ...(isUnified ? {} : { external: [] }),
           output: {
             entryFileNames: '[name]',
             exports: 'auto',
@@ -1153,11 +1195,22 @@ export async function build(args: {
       }))
     }
 
-    // swap out for the built middleware path
+    // swap out for the built middleware path.
+    // page routes have compiled middleware paths attached via buildPage
+    // (buildInfo.middlewares). api routes don't go through buildPage, so fall
+    // back to the builtMiddlewares map keyed by the middleware source file.
     const buildInfo = builtRoutes.find((x) => x.routeFile === route.file)
-    if (built.middlewares && buildInfo?.middlewares) {
+    if (built.middlewares) {
       for (const [index, mw] of built.middlewares.entries()) {
-        mw.contextKey = buildInfo.middlewares[index]
+        const viaBuildInfo = buildInfo?.middlewares?.[index]
+        if (viaBuildInfo) {
+          mw.contextKey = viaBuildInfo
+          continue
+        }
+        const viaMiddlewareMap = builtMiddlewares[mw.contextKey]
+        if (viaMiddlewareMap) {
+          mw.contextKey = viaMiddlewareMap
+        }
       }
     }
 

--- a/packages/one/src/server/getServerManifest.ts
+++ b/packages/one/src/server/getServerManifest.ts
@@ -150,13 +150,10 @@ export function getServerManifest(route: RouteNode): OneRouterServerManifestV1 {
   const addedMiddlewares: Record<string, boolean> = {}
 
   for (const [path, node] of flat) {
-    if (node.type === 'api') {
-      const route = getGeneratedNamedRouteRegex(path, node)
-      apiRoutes.push(route)
-      allRoutes.push(route)
-      continue
-    }
-
+    // collect middlewares for every route type, not just pages. a middleware
+    // nested under api/ (e.g. app/api/admin/_middleware.ts) must still end up
+    // in middlewareRoutes so the build pipeline compiles it — otherwise the
+    // compiled file never exists and runtime lookups return undefined.
     if (node.middlewares?.length) {
       for (const middleware of node.middlewares) {
         if (!addedMiddlewares[middleware.contextKey]) {
@@ -164,6 +161,13 @@ export function getServerManifest(route: RouteNode): OneRouterServerManifestV1 {
           middlewareRoutes.push(getGeneratedNamedRouteRegex(path, middleware))
         }
       }
+    }
+
+    if (node.type === 'api') {
+      const route = getGeneratedNamedRouteRegex(path, node)
+      apiRoutes.push(route)
+      allRoutes.push(route)
+      continue
     }
 
     const route = getGeneratedNamedRouteRegex(path, node)

--- a/packages/vxrn/src/exports/build.ts
+++ b/packages/vxrn/src/exports/build.ts
@@ -247,6 +247,13 @@ export const build = async (optionsIn: VXRNOptions, buildArgs: BuildArgs = {}) =
   // default to cjs
   const shouldOutputCJS = getServerCJSSetting(options)
 
+  // unified mode: drop the blanket ssr.noExternal, keep only react inlined
+  // (externalizing react broke prod builds, see commit 423b9cb0c).
+  // other deps let rolldown decide — user can still add externals via
+  // build.server.config.ssr.external or rolldownOptions.external.
+  const isUnified =
+    typeof serverOptions === 'object' && serverOptions !== null && serverOptions.unified === true
+
   let serverBuildConfig = mergeConfig(webBuildConfig, {
     plugins: [excludeAPIAndMiddlewareRoutesPlugin, ...globalThis.__vxrnAddWebPluginsProd],
 
@@ -258,10 +265,7 @@ export const build = async (optionsIn: VXRNOptions, buildArgs: BuildArgs = {}) =
     },
 
     ssr: {
-      noExternal: true,
-      // we used to do this i think to make our patching react work?
-      // but stopped working for prod builds due to duplicate react somehow
-      // external: ['react', 'react-dom', 'expo-modules-core'],
+      noExternal: isUnified ? ['react', 'react-dom'] : true,
       optimizeDeps: optimizeDepsWithoutRolldown,
     },
 

--- a/packages/vxrn/src/types.ts
+++ b/packages/vxrn/src/types.ts
@@ -56,6 +56,20 @@ export type VXRNBuildOptions = {
    * Uses Vite mergeConfig to overwrite any build configuration during build
    */
   config?: InlineConfig
+
+  /**
+   * Unify the server-side build. Api routes and middlewares share the SSR
+   * server's config (same defines, plugins, externalization rules) instead of
+   * deriving from the web/client build. Also drops the blanket
+   * `ssr.noExternal: true` so rolldown can externalize what it cannot bundle.
+   *
+   * This is the direction One is moving — in the next major it becomes the
+   * default and api/middleware lose their separate config surfaces entirely.
+   * Opt in now to avoid surprise later.
+   *
+   * @default false
+   */
+  unified?: boolean
 }
 
 export type VXRNOptions = {

--- a/packages/vxrn/types/types.d.ts
+++ b/packages/vxrn/types/types.d.ts
@@ -45,6 +45,19 @@ export type VXRNBuildOptions = {
      * Uses Vite mergeConfig to overwrite any build configuration during build
      */
     config?: InlineConfig;
+    /**
+     * Unify the server-side build. Api routes and middlewares share the SSR
+     * server's config (same defines, plugins, externalization rules) instead of
+     * deriving from the web/client build. Also drops the blanket
+     * `ssr.noExternal: true` so rolldown can externalize what it cannot bundle.
+     *
+     * This is the direction One is moving — in the next major it becomes the
+     * default and api/middleware lose their separate config surfaces entirely.
+     * Opt in now to avoid surprise later.
+     *
+     * @default false
+     */
+    unified?: boolean;
 };
 export type VXRNOptions = {
     /**

--- a/tests/test-build-unified/.gitignore
+++ b/tests/test-build-unified/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+.wrangler/

--- a/tests/test-build-unified/app/_layout.tsx
+++ b/tests/test-build-unified/app/_layout.tsx
@@ -1,0 +1,16 @@
+import { Slot } from 'one'
+
+export default function Layout() {
+  return (
+    <html>
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Unified Build Test</title>
+      </head>
+      <body>
+        <Slot />
+      </body>
+    </html>
+  )
+}

--- a/tests/test-build-unified/app/_middleware.ts
+++ b/tests/test-build-unified/app/_middleware.ts
@@ -1,0 +1,7 @@
+import { createMiddleware } from 'one'
+
+export default createMiddleware(async ({ request, next }) => {
+  const response = await next()
+  response.headers.set('X-Root-Middleware', 'root-ran')
+  return response
+})

--- a/tests/test-build-unified/app/api/axios-import+api.ts
+++ b/tests/test-build-unified/app/api/axios-import+api.ts
@@ -1,0 +1,13 @@
+// axios is a classic node-first CJS package that references node:http / node:https.
+// we don't actually make a request here — just verify the module bundles and
+// its public shape is reachable at runtime (this is the class of package that
+// breaks builds under ssr.noExternal: true + rolldown).
+import axios from 'axios'
+
+export async function GET() {
+  return Response.json({
+    loaded: typeof axios === 'function' || typeof axios === 'object',
+    hasGet: typeof axios?.get === 'function',
+    hasPost: typeof axios?.post === 'function',
+  })
+}

--- a/tests/test-build-unified/app/api/date-fmt+api.ts
+++ b/tests/test-build-unified/app/api/date-fmt+api.ts
@@ -1,0 +1,13 @@
+// dual-package (CJS/ESM) pure-JS dep — verifies no-externalize path
+import { format } from 'date-fns'
+import ms from 'ms'
+
+export async function GET() {
+  // use a noon-UTC date so local-time formatting doesn't cross a day boundary
+  // regardless of which timezone workerd/miniflare runs in
+  const d = new Date('2024-06-15T12:00:00Z')
+  return Response.json({
+    formatted: format(d, 'yyyy-MM-dd'),
+    ms: ms('1h'),
+  })
+}

--- a/tests/test-build-unified/app/api/echo/[param]+api.ts
+++ b/tests/test-build-unified/app/api/echo/[param]+api.ts
@@ -1,0 +1,7 @@
+// nested + dynamic param route
+export async function GET(
+  request: Request,
+  { params }: { params: { param: string } }
+) {
+  return Response.json({ echo: params.param })
+}

--- a/tests/test-build-unified/app/api/hello+api.ts
+++ b/tests/test-build-unified/app/api/hello+api.ts
@@ -1,0 +1,4 @@
+// plain api route, no extra deps — sanity baseline
+export async function GET() {
+  return Response.json({ hello: 'world' })
+}

--- a/tests/test-build-unified/app/api/nested/[slug]+api.ts
+++ b/tests/test-build-unified/app/api/nested/[slug]+api.ts
@@ -1,0 +1,7 @@
+// nested + dynamic — exercises the route flattening path in unified mode
+export async function GET(
+  request: Request,
+  { params }: { params: { slug: string } }
+) {
+  return Response.json({ nested: true, slug: params.slug })
+}

--- a/tests/test-build-unified/app/api/nested/_middleware.ts
+++ b/tests/test-build-unified/app/api/nested/_middleware.ts
@@ -1,0 +1,7 @@
+import { createMiddleware } from 'one'
+
+export default createMiddleware(async ({ request, next }) => {
+  const response = await next()
+  response.headers.set('X-Nested-Middleware', 'nested-ran')
+  return response
+})

--- a/tests/test-build-unified/app/api/nested/ping+api.ts
+++ b/tests/test-build-unified/app/api/nested/ping+api.ts
@@ -1,0 +1,4 @@
+// inside a nested middleware — verifies nested mw runs on this route
+export async function GET() {
+  return Response.json({ pong: true })
+}

--- a/tests/test-build-unified/app/api/zod-validate+api.ts
+++ b/tests/test-build-unified/app/api/zod-validate+api.ts
@@ -1,0 +1,13 @@
+// pure ESM dep — should bundle cleanly
+import { z } from 'zod'
+
+const schema = z.object({ name: z.string().min(1) })
+
+export async function POST(request: Request) {
+  const body = await request.json()
+  const parsed = schema.safeParse(body)
+  if (!parsed.success) {
+    return Response.json({ ok: false, errors: parsed.error.issues }, { status: 400 })
+  }
+  return Response.json({ ok: true, name: parsed.data.name })
+}

--- a/tests/test-build-unified/app/index.tsx
+++ b/tests/test-build-unified/app/index.tsx
@@ -1,0 +1,11 @@
+export function loader() {
+  return { message: 'unified-build SSG' }
+}
+
+export default function Home() {
+  return (
+    <div>
+      <h1 id="home-title">Unified Build Test</h1>
+    </div>
+  )
+}

--- a/tests/test-build-unified/app/spa-page+spa.tsx
+++ b/tests/test-build-unified/app/spa-page+spa.tsx
@@ -1,0 +1,7 @@
+export default function SPA() {
+  return (
+    <div>
+      <h1 id="spa-title">SPA</h1>
+    </div>
+  )
+}

--- a/tests/test-build-unified/app/ssr-page+ssr.tsx
+++ b/tests/test-build-unified/app/ssr-page+ssr.tsx
@@ -1,0 +1,15 @@
+import { useLoader } from 'one'
+
+export function loader() {
+  return { mode: 'ssr', at: Date.now() }
+}
+
+export default function SSR() {
+  const data = useLoader(loader)
+  return (
+    <div>
+      <h1 id="ssr-title">SSR</h1>
+      <p id="ssr-mode">{data.mode}</p>
+    </div>
+  )
+}

--- a/tests/test-build-unified/package.json
+++ b/tests/test-build-unified/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "test-build-unified",
+  "version": "1.15.10-1776565272880",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "one dev",
+    "build:web": "one build",
+    "serve": "wrangler dev dist/worker.js --port 3458",
+    "test": "vitest --run --reporter=verbose"
+  },
+  "dependencies": {
+    "axios": "^1.7.0",
+    "date-fns": "^3.6.0",
+    "ms": "^2.1.3",
+    "one": "workspace:*",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/ms": "^0.7.34",
+    "kill-my-port": "1.1.2",
+    "typescript": "^5.7.3",
+    "vitest": "^4.1.0",
+    "wrangler": "4.60.0"
+  }
+}

--- a/tests/test-build-unified/setup.ts
+++ b/tests/test-build-unified/setup.ts
@@ -1,0 +1,119 @@
+/**
+ * Vitest global setup for the unified build mode fixture.
+ *
+ * Builds the app with build.server.unified: true, boots wrangler dev
+ * against the resulting worker, and exposes ONE_SERVER_URL to tests.
+ */
+
+import { spawn, execSync, type ChildProcess } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import type { GlobalSetupContext } from 'vitest/node'
+
+const testDir = process.cwd()
+const PORT = 3458
+let serverProcess: ChildProcess | null = null
+
+async function waitForServer(url: string, maxRetries = 60): Promise<boolean> {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const response = await fetch(url, { method: 'HEAD' })
+      if (response.ok || response.status < 500) {
+        return true
+      }
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+  }
+  return false
+}
+
+function killProcessTree(pid: number) {
+  try {
+    if (process.platform === 'win32') {
+      execSync(`taskkill /pid ${pid} /T /F`, { stdio: 'ignore' })
+    } else {
+      execSync(`kill -9 -${pid} 2>/dev/null || kill -9 ${pid}`, { stdio: 'ignore' })
+    }
+  } catch {}
+}
+
+export async function setup({ provide }: GlobalSetupContext) {
+  console.log('[test-build-unified] Starting setup...')
+
+  if (!process.env.SKIP_BUILD) {
+    console.log('[test-build-unified] Building with unified mode + cloudflare...')
+    try {
+      execSync('bun run build:web', {
+        cwd: testDir,
+        stdio: 'inherit',
+        env: {
+          ...process.env,
+          NODE_ENV: 'production',
+          ONE_SERVER_URL: `http://localhost:${PORT}`,
+        },
+      })
+    } catch (err) {
+      console.error('[test-build-unified] Build failed:', err)
+      throw err
+    }
+  }
+
+  try {
+    execSync(`bun kill-my-port ${PORT}`)
+  } catch {}
+
+  const workerFile = join(testDir, 'dist', 'worker.js')
+  if (!existsSync(workerFile)) {
+    throw new Error(`worker not found at ${workerFile}`)
+  }
+
+  console.log('[test-build-unified] Starting wrangler dev server...')
+  serverProcess = spawn(
+    'bunx',
+    [
+      'wrangler',
+      'dev',
+      'dist/worker.js',
+      '--port',
+      String(PORT),
+      '--config',
+      join(testDir, 'dist', 'wrangler.jsonc'),
+    ],
+    {
+      cwd: testDir,
+      stdio: 'inherit',
+      detached: true,
+      env: { ...process.env },
+    }
+  )
+
+  serverProcess.unref()
+
+  const serverUrl = `http://localhost:${PORT}`
+  const ready = await waitForServer(serverUrl)
+  if (!ready) {
+    throw new Error(`wrangler server failed to start at ${serverUrl}`)
+  }
+
+  console.log(`[test-build-unified] Server ready at ${serverUrl}`)
+  process.env.ONE_SERVER_URL = serverUrl
+  provide('testInfo', { testDir, serverUrl })
+}
+
+export async function teardown() {
+  console.log('[test-build-unified] Tearing down...')
+  if (serverProcess?.pid) {
+    killProcessTree(serverProcess.pid)
+  }
+  console.log('[test-build-unified] Force exiting')
+  process.exit(0)
+}
+
+declare module 'vitest' {
+  export interface ProvidedContext {
+    testInfo: {
+      testDir: string
+      serverUrl: string
+    }
+  }
+}

--- a/tests/test-build-unified/tests/unified-build.test.ts
+++ b/tests/test-build-unified/tests/unified-build.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for build.server.unified: true
+ *
+ * What "unified" means:
+ *  - api + middleware + server SSR all built in one viteBuild call (single rolldown pass)
+ *  - noExternal: true is dropped; rolldown externalizes what it can't bundle
+ *  - user-configurable via standard vite ssr.external / rolldownOptions.external
+ *  - output file layout (dist/server, dist/api, dist/middlewares) is preserved
+ *    so the CF worker lazy-import map and node route dispatch keep working
+ *
+ * The fixture's vite.config.ts enables unified mode. The setup.ts global
+ * build step is what would fail first if the flag is not wired up at all
+ * (unknown config key) or is wired up wrong (build fails).
+ */
+
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const serverUrl = process.env.ONE_SERVER_URL || 'http://localhost:3458'
+const distDir = join(process.cwd(), 'dist')
+
+describe('unified build — dist layout', () => {
+  it('produces a cloudflare worker bundle', () => {
+    expect(existsSync(join(distDir, 'worker.js'))).toBe(true)
+  })
+
+  it('emits server entry at dist/server/_virtual_one-entry.js', () => {
+    expect(existsSync(join(distDir, 'server', '_virtual_one-entry.js'))).toBe(true)
+  })
+
+  it('emits api routes under dist/api/', () => {
+    expect(existsSync(join(distDir, 'api', 'api', 'hello.js'))).toBe(true)
+    expect(existsSync(join(distDir, 'api', 'api', 'zod-validate.js'))).toBe(true)
+    // axios + date-fmt files also emit — runtime behavior validated separately
+    // (see KNOWN-BROKEN note below)
+  })
+
+  it('emits dynamic-param api route with brackets replaced', () => {
+    // both vite + rolldown-vite transform [param] → _param_ in output filenames
+    expect(existsSync(join(distDir, 'api', 'api', 'echo', '_param_.js'))).toBe(true)
+  })
+
+  it('emits nested api routes', () => {
+    expect(existsSync(join(distDir, 'api', 'api', 'nested', 'ping.js'))).toBe(true)
+    expect(existsSync(join(distDir, 'api', 'api', 'nested', '_slug_.js'))).toBe(true)
+  })
+
+  it('emits middlewares under dist/middlewares/', () => {
+    // root middleware — framework uses _middleware as the bare filename
+    const distFiles = readFileSync(join(distDir, 'buildInfo.json'), 'utf-8')
+    expect(distFiles).toContain('middlewares')
+  })
+
+  it('wrangler.jsonc still references api/middlewares via find_additional_modules', () => {
+    const config = JSON.parse(readFileSync(join(distDir, 'wrangler.jsonc'), 'utf-8'))
+    expect(config.find_additional_modules).toBe(true)
+    const globs = (config.rules as Array<{ globs: string[] }>).flatMap((r) => r.globs)
+    expect(globs).toContain('./api/**/*.js')
+    expect(globs).toContain('./middlewares/**/*.js')
+    expect(globs).toContain('./server/**/*.js')
+  })
+})
+
+describe('unified build — runtime behavior', () => {
+  it('serves the SSG home page', async () => {
+    const res = await fetch(`${serverUrl}/`)
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('Unified Build Test')
+  })
+
+  it('serves the SSR page with loader data', async () => {
+    const res = await fetch(`${serverUrl}/ssr-page`)
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('<h1 id="ssr-title">SSR</h1>')
+    expect(text).toContain('ssr')
+  })
+
+  it('answers baseline api route', async () => {
+    const res = await fetch(`${serverUrl}/api/hello`)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ hello: 'world' })
+  })
+
+  it('zod-based api route validates input (pure ESM dep bundles correctly)', async () => {
+    const res = await fetch(`${serverUrl}/api/zod-validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'alice' }),
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true, name: 'alice' })
+  })
+
+  it('zod-based api route rejects invalid input', async () => {
+    const res = await fetch(`${serverUrl}/api/zod-validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  // KNOWN-BROKEN on Cloudflare: these deps (and the whole klaviyo-api /
+  // stripe-node / twilio class) fail under rolldown's CJS bundling into the
+  // hand-rolled worker. Orthogonal to unified mode — separate CF/rolldown
+  // bundling issue. Kept as reproducers, skipped in CI.
+  it.skip('date-fns + ms bundle and run (CJS/dual-package deps)', async () => {
+    const res = await fetch(`${serverUrl}/api/date-fmt`)
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { formatted: string; ms: number }
+    expect(json.formatted).toBe('2024-06-15')
+    expect(json.ms).toBe(3_600_000)
+  })
+
+  it.skip('axios can be imported in an api route (node-first CJS + node:http)', async () => {
+    const res = await fetch(`${serverUrl}/api/axios-import`)
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as {
+      loaded: boolean
+      hasGet: boolean
+      hasPost: boolean
+    }
+    expect(json.loaded).toBe(true)
+    expect(json.hasGet).toBe(true)
+    expect(json.hasPost).toBe(true)
+  })
+
+  it('dynamic-param api route receives params', async () => {
+    const res = await fetch(`${serverUrl}/api/echo/hello`)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ echo: 'hello' })
+  })
+
+  it('nested static api route responds', async () => {
+    const res = await fetch(`${serverUrl}/api/nested/ping`)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ pong: true })
+  })
+
+  it('nested dynamic api route responds with param', async () => {
+    const res = await fetch(`${serverUrl}/api/nested/abc123`)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ nested: true, slug: 'abc123' })
+  })
+})
+
+describe('unified build — middleware chain', () => {
+  it('root middleware runs on SSG pages', async () => {
+    const res = await fetch(`${serverUrl}/`)
+    expect(res.headers.get('X-Root-Middleware')).toBe('root-ran')
+  })
+
+  it('root middleware runs on SSR pages', async () => {
+    const res = await fetch(`${serverUrl}/ssr-page`)
+    expect(res.headers.get('X-Root-Middleware')).toBe('root-ran')
+  })
+
+  it('root middleware runs on api routes', async () => {
+    const res = await fetch(`${serverUrl}/api/hello`)
+    expect(res.headers.get('X-Root-Middleware')).toBe('root-ran')
+  })
+
+  it('nested middleware runs on nested routes', async () => {
+    const res = await fetch(`${serverUrl}/api/nested/ping`)
+    expect(res.headers.get('X-Nested-Middleware')).toBe('nested-ran')
+    // root middleware should also still run (chain)
+    expect(res.headers.get('X-Root-Middleware')).toBe('root-ran')
+  })
+
+  it('nested middleware does NOT run on sibling routes outside nested/', async () => {
+    const res = await fetch(`${serverUrl}/api/hello`)
+    expect(res.headers.get('X-Nested-Middleware')).toBeNull()
+    expect(res.headers.get('X-Root-Middleware')).toBe('root-ran')
+  })
+})
+

--- a/tests/test-build-unified/tsconfig.json
+++ b/tests/test-build-unified/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["app/**/*", "tests/**/*", "setup.ts", "vite.config.ts", "vitest.config.ts"]
+}

--- a/tests/test-build-unified/vite.config.ts
+++ b/tests/test-build-unified/vite.config.ts
@@ -1,0 +1,19 @@
+import { one } from 'one/vite'
+
+export default {
+  plugins: [
+    one({
+      web: {
+        deploy: 'cloudflare',
+      },
+      build: {
+        server: {
+          // unified build mode: api/middleware share the SSR server config
+          // (same defines, plugins, externalization rules) and the blanket
+          // ssr.noExternal: true is dropped.
+          unified: true,
+        },
+      },
+    }),
+  ],
+}

--- a/tests/test-build-unified/vitest.config.ts
+++ b/tests/test-build-unified/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  clearScreen: false,
+  test: {
+    globalSetup: './setup.ts',
+    include: ['tests/**/*.test.ts'],
+    fileParallelism: false,
+    testTimeout: 60000,
+    hookTimeout: 90000,
+    retry: 2,
+  },
+})


### PR DESCRIPTION
## Summary

- **`build.server.unified: true` (opt-in)** — api routes + middlewares share the SSR server's config (same defines, plugins, externalization rules) instead of deriving from the web/client build. Drops blanket `ssr.noExternal: true` to `['react', 'react-dom']` only; users control externals via standard vite `ssr.external` / `rolldownOptions.external`.
- **Nested api middleware bug fix** — `getServerManifest` skipped middleware collection for api routes (continue'd past the loop), so middlewares nested under `app/api/` were never built. Also fixes the companion `buildInfo.middlewares` contextKey rewrite to fall through to the `builtMiddlewares` map for api routes (page routes go through `buildPage`, api routes don't).
- **Starter template** (`examples/one-basic/vite.config.ts`) opts into unified mode so new projects get the clean shape from the start.
- **New test fixture** (`tests/test-build-unified/`) — SSG + SSR + SPA pages, 6 api routes including nested + dynamic params, root + nested middlewares, 20 passing tests.

## Why

The `api` build path derived from `webBuildConfig` with `noExternal: true` hard-coded (see build.ts:388 TODO), which meant every api route and middleware bundled every dep. The blanket `noExternal: true` also broke for Node-first CJS packages (klaviyo-api, stripe-node, axios class) when their output reached the CF worker pass. Unified mode is the path toward next major's default — api/middleware disappear as separate configuration surfaces and become entries into the server env.

## Known-not-fixed

`axios` / `date-fns+ms` / `klaviyo-api`-class CJS deps still fail in Cloudflare workers under both legacy and unified modes — that's a separate rolldown/unenv bundling issue. Fixture has those two as `it.skip` reproducers with a comment. Tracked separately for follow-up with `@cloudflare/vite-plugin`.

## Test plan

- [ ] `cd tests/test-build-unified && bun run test` → 20/22 (2 skipped)
- [ ] `cd tests/test/tests && bun run test:prod` → no regression
- [ ] `cd tests/test-cloudflare && bun run test` → 27/27 (legacy path unchanged)
- [ ] Downstream: build ~/takeout-free, ~/takeout, ~/chat against canary build
- [ ] ~/chat e2e against prod after canary deploy