### PR TITLE
ci: trigger Checks and Tests on merge_group events

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,11 +11,12 @@ on:
     paths-ignore:
       - '**/*.md'
       - '**/CHANGELOG.md'
+  merge_group:
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
 
 jobs:
   checks:


### PR DESCRIPTION
## Summary
The repo's branch protection requires merging via the GitHub merge queue, and the queue's required check is `tests`. But `.github/workflows/checks.yml` only had `on: push / pull_request / workflow_dispatch` — no `merge_group` trigger. So the queue had no way to actually run `tests` on a merge candidate, and every queued PR sat for ~1h then got dequeued (e.g. #704).

This PR adds the `merge_group` trigger so the workflow runs on the queue's `gh-readonly-queue/main/...` candidates. It also excludes those queue refs from `cancel-in-progress` so that newly enqueued candidates don't cancel an in-flight one's checks.

## Test plan
- [ ] After merging, the next PR queued should actually run a `Checks and Tests` workflow on the merge candidate (visible at /onejs/one/actions, filtered by `Event: merge_group`)
- [ ] Queue should drain instead of timing out