### PR TITLE
docs: mention onestack/skills for AI agents

### DIFF
--- a/apps/onestack.dev/data/docs/guides.mdx
+++ b/apps/onestack.dev/data/docs/guides.mdx
@@ -13,4 +13,5 @@ Guides to common patterns are here. If you'd like to contribute a Guide, please 
   <Card href="/docs/guides-ios-native" title="Build or Run the Native iOS App" category="Native" />
   <Card href="/docs/guides-eas" title="Build and Deliver Native Apps with EAS" category="Native" />
   <Card href="/docs/guides-migrating-create-react-app-cra-to-vite-with-one" title="Migrate from Create React App to One" category="Migrating" />
+  <Card href="https://github.com/onestack/skills" title="AI Agent Skills" category="AI" />
 </CardCol>

--- a/apps/onestack.dev/data/docs/installation.mdx
+++ b/apps/onestack.dev/data/docs/installation.mdx
@@ -13,6 +13,16 @@ The CLI will guide you through the process of bootstrapping one of our starter t
 
 If this is your first One app, we recommend taking this route, as you can choose between bare-bones example all the way up to a full stack with a user system and authentication. We will be launching more starters as the project matures.
 
+<Notice>
+  **Using an AI agent?** Install the official One skills so Claude Code, Cursor, Codex, etc. know how to build with One:
+
+  ```bash
+  npx skills add onestack/skills
+  ```
+
+  Full list and per-agent install instructions: [github.com/onestack/skills](https://github.com/onestack/skills).
+</Notice>
+
 ### 5-minute tutorial
 
 While we recommend using a preset to get started, it's helpful to walk through creating a new One app from scratch.


### PR DESCRIPTION
Adds a brief pointer to the [onestack/skills](https://github.com/onestack/skills) marketplace so AI-agent users can discover it from the docs.

- Notice block on the Installation page right after `npx one`, with the `npx skills add onestack/skills` install line.
- New "AI Agent Skills" card on the Guides index linking to the repo.

Both link out to the GitHub repo rather than introducing a new docs page.