### PR TITLE
feat(vxrn): default to real EXUpdates manifest, opt-out for legacy empty placeholder

### DIFF
--- a/apps/onestack.dev/data/docs/guides-ota-updates.mdx
+++ b/apps/onestack.dev/data/docs/guides-ota-updates.mdx
@@ -86,6 +86,81 @@ Only publish OTA updates for changes that don't touch the native binary:
 
 For those, bump your app `version`, build a fresh TestFlight/Play binary, and only then publish OTA updates against the new runtime. The `appVersion` strategy (supported by both libraries) gates delivery so devices on the old version don't receive incompatible updates.
 
+## Monorepo asset resolution
+
+In a pnpm/yarn workspace, Metro's `projectRoot`, `watchFolders`, and `server.unstable_serverRoot` need to agree on which directory your app lives in. When they disagree, project-local assets (`apps/<your-app>/assets/logo.png` referenced via `require('./assets/logo.png')`) can silently drop from the production native bundle — the file ships in the binary but its `AssetRegistry.registerAsset(...)` descriptor never makes it into the Hermes bundle, so `<Image source={require(...)} />` renders blank. Assets from `node_modules` keep registering because their paths are stable relative to whichever root Metro picks.
+
+Two settings keep this consistent for production-like builds:
+
+**1. Pin Metro's server root to your app directory** in `vite.config.ts`, scoped to production-shaped builds so dev isn't affected:
+
+```ts
+import { resolve } from 'node:path'
+import { one } from 'one/vite'
+
+const projectRoot = resolve(__dirname)
+const isProdLike =
+  process.env.NODE_ENV === 'production' || process.env.EAS_BUILD === 'true'
+
+export default {
+  root: projectRoot,
+  plugins: [
+    one({
+      native: {
+        bundler: 'metro',
+        bundlerOptions: {
+          argv: { projectRoot, cwd: projectRoot },
+          defaultConfigOverrides: (config) => ({
+            ...config,
+            projectRoot,
+            ...(isProdLike && {
+              server: {
+                ...config?.server,
+                unstable_serverRoot: projectRoot,
+              },
+            }),
+          }),
+        },
+      },
+    }),
+  ],
+}
+```
+
+`unstable_serverRoot` is a Metro internal field — name may change across Metro versions. Pin your Metro version if you depend on it.
+
+**2. Set `EXPO_NO_METRO_WORKSPACE_ROOT=1` in EAS production env** so Expo doesn't elevate `projectRoot` to the workspace root behind your back:
+
+```json
+// eas.json
+{
+  "build": {
+    "production": {
+      "env": {
+        "EXPO_NO_METRO_WORKSPACE_ROOT": "1"
+      }
+    }
+  }
+}
+```
+
+To verify after `expo export --platform ios`, the asset's content hash should appear as a filename in `dist/assets/` and as an entry in `dist/metadata.json` under `fileMetadata.ios.assets`. If a project-local asset is missing from `metadata.json` but the file you `require()` exists on disk, this is the symptom.
+
+**3. The iOS EXUpdates `app.manifest` already gets generated for you.** Without settings 1 and 2 above, vxrn's iOS Podfile patch can still run the upstream `create-updates-resources-ios.sh` to produce a real `EXUpdates.bundle/app.manifest` (with `nsBundleDir`/`nsBundleFilename` entries for every embedded asset). But the asset paths in the manifest only match what vxrn actually writes into the `.app` when the Metro server root is pinned to `projectRoot`. If they don't match, expo-asset's runtime transformer falls back to `uri:""` for project-local `require()`'d images and the logo renders blank in App Store / TestFlight builds. `node_modules` assets work either way.
+
+If you have a reason to skip the real manifest (very large bundles where the extra Metro server startup in the build phase is costly, or a project with no `require()`'d project-local images and a JS-side onError fallback for everything else), opt out:
+
+```json
+// ios/Podfile.properties.json
+{
+  "one.useEmptyExpoUpdatesManifest": "true"
+}
+```
+
+This restores the legacy `{ "assets": [] }` + `SKIP_BUNDLING=1` behavior.
+
+To verify the real manifest is working: locate the installed `.app/EXUpdates.bundle/app.manifest`, confirm `assets` is non-empty, and check that each entry's `nsBundleDir` + `nsBundleFilename` actually exists inside the `.app`. At runtime, a `console.log(Image.resolveAssetSource(require('./assets/logo.png')))` should return a `file://.../.expo-internal/<hash>.png` URI rather than `uri:""`.
+
 ## Publishing locally (expo-updates only)
 
 `eas update` from your own machine works the same way EAS workers run it — but One's auto-setup only fires when `CI=1` or `EAS_BUILD=true` is set, so your local working tree stays clean. After dependencies are installed, generate the same shims explicitly before publishing:

--- a/packages/vxrn/expo-plugin.cjs
+++ b/packages/vxrn/expo-plugin.cjs
@@ -168,13 +168,29 @@ const plugin = (config, options = {}) => {
             return config
           }
 
+          // default: generate a real EXUpdates manifest so project-local
+          // require()'d assets resolve at runtime. opt-out for callers who
+          // need the legacy empty-placeholder behavior (e.g. apps without
+          // expo-updates fully wired or with very large bundles where the
+          // extra Metro invocation in the build phase is unacceptable).
+          const useEmptyManifest = getPodfilePropsOptOut(
+            propsPath,
+            'one.useEmptyExpoUpdatesManifest'
+          )
+
           const podfile = fs.readFileSync(podfilePath, 'utf8')
-          const next = injectExpoUpdatesIosResourcesPatchIntoPodfile(podfile)
+          const next = injectExpoUpdatesIosResourcesPatchIntoPodfile(podfile, {
+            generateRealManifest: !useEmptyManifest,
+          })
           if (next !== podfile) {
             fs.writeFileSync(podfilePath, next, 'utf8')
             console.info(
-              '[vxrn] patched Podfile to skip expo-updates Expo Metro invocation\n' +
-                '       to disable: set "one.disableExpoUpdatesIosShellScriptPatch": "true" in ios/Podfile.properties.json'
+              useEmptyManifest
+                ? '[vxrn] patched Podfile to write empty EXUpdates manifest (legacy mode)\n' +
+                  '       to switch to real-manifest mode: remove "one.useEmptyExpoUpdatesManifest" from ios/Podfile.properties.json'
+                : '[vxrn] patched Podfile to generate real EXUpdates manifest\n' +
+                  '       to fall back to empty placeholder: set "one.useEmptyExpoUpdatesManifest": "true" in ios/Podfile.properties.json\n' +
+                  '       to disable patch entirely: set "one.disableExpoUpdatesIosShellScriptPatch": "true" in ios/Podfile.properties.json'
             )
           }
           return config
@@ -653,26 +669,72 @@ function injectSwift6WorkaroundIntoPodfile(podfile) {
 
 /**
  * Replace the EXUpdates pod's "Generate updates resources for expo-updates"
- * Xcode build phase with one that writes a minimal embedded manifest and sets
- * SKIP_BUNDLING=1.
+ * Xcode build phase. Two modes:
  *
- * Why: expo-updates' shell script runs Expo Metro on the JS entry to produce
- * `app.manifest`. Under One/VxRN, release bundling is routed through the
- * react-native CLI override so One's router transforms are wired; Expo Metro
- * doesn't see those transforms and (on monorepos) often can't even resolve the
- * entry. The wrapped script still runs the original so fingerprint/resource
- * side-effects fire — only the Metro bundle step is skipped.
+ *  - Default (`generateRealManifest=true`): run Expo's real
+ *    `create-updates-resources-ios.sh` with `EXPO_NO_METRO_WORKSPACE_ROOT=1`
+ *    so the generated `app.manifest`'s `nsBundleDir`/`nsBundleFilename`
+ *    entries match the asset paths vxrn's iOS bundler writes into the
+ *    `.app`. expo-asset's runtime transformer then resolves project-local
+ *    `require()`'d assets to real local file URIs. For this to work end to
+ *    end the app's Metro config also needs to pin `server.unstable_serverRoot`
+ *    to `projectRoot` for release-shaped native bundles, otherwise vxrn
+ *    writes assets at workspace-rooted paths while the manifest points at
+ *    project-rooted paths and the mismatch leaves project-local images
+ *    blank (same outcome as legacy mode below, but with no build-time
+ *    regression). `node_modules` assets resolve correctly either way.
  *
- * Disable: set "one.disableExpoUpdatesIosShellScriptPatch": "true" in
- * ios/Podfile.properties.json.
+ *  - Legacy (`generateRealManifest=false`): write a minimal empty
+ *    `{ assets: [] }` app.manifest and run the original script with
+ *    SKIP_BUNDLING=1 so only its fingerprint/resource side-effects fire.
+ *    Faster (no extra Metro server startup in the build phase), but every
+ *    project-local `require()`'d asset resolves to `uri:""` at runtime.
+ *    Only choose this if you have no project-local assets, or you have a
+ *    JS-side onError fallback for every image, or the extra Metro
+ *    invocation in the build phase is unacceptable.
+ *
+ * Disable the patch entirely: set
+ * `"one.disableExpoUpdatesIosShellScriptPatch": "true"` in
+ * `ios/Podfile.properties.json`. The upstream script will then run
+ * untouched, which on most pnpm monorepos fails to resolve the One entry
+ * file and aborts the build.
+ *
+ * Opt into the legacy empty-placeholder mode: set
+ * `"one.useEmptyExpoUpdatesManifest": "true"` in
+ * `ios/Podfile.properties.json`.
+ *
+ * See the "Monorepo asset resolution" section of the OTA Updates docs for
+ * the full picture (server-root pinning + this manifest mode together).
  */
+// Preserved verbatim so existing patched Podfiles re-trigger the idempotency
+// check on next pod install instead of getting the patch injected twice.
 const EXPO_UPDATES_METRO_SKIP_MARKER =
   '# [vxrn/one] skip expo-updates Expo Metro for embedded manifest'
 
-function injectExpoUpdatesIosResourcesPatchIntoPodfile(podfile) {
+function injectExpoUpdatesIosResourcesPatchIntoPodfile(podfile, options = {}) {
   if (podfile.includes(EXPO_UPDATES_METRO_SKIP_MARKER)) {
     return podfile
   }
+
+  // default to real-manifest mode. legacy empty-placeholder mode is only
+  // produced when the caller explicitly passes generateRealManifest: false.
+  const generateRealManifest = options.generateRealManifest !== false
+
+  // shell snippet that produces app.manifest before the upstream script runs.
+  // either an empty placeholder + SKIP_BUNDLING=1 (default), or a real manifest
+  // gated on EXPO_NO_METRO_WORKSPACE_ROOT so Expo Metro can resolve the entry.
+  const prelude = generateRealManifest
+    ? `          # [vxrn/one] opt-in: generate real EXUpdates manifest. requires
+          # the app's Metro config to pin server.unstable_serverRoot to the
+          # project root for release-shaped native bundles; otherwise asset
+          # paths in the manifest won't match what vxrn writes into the .app.
+          export EXPO_NO_METRO_WORKSPACE_ROOT=1`
+    : `          # default: write an empty manifest and skip the bundle step.
+          # project-local require()'d assets will resolve to uri:"" at runtime.
+          # set "one.generateExpoUpdatesManifest": "true" in
+          # ios/Podfile.properties.json to switch to real-manifest mode.
+          "\${NODE_BINARY:-node}" -e "const c=require('node:crypto');const f=require('node:fs');f.writeFileSync(process.argv[1],JSON.stringify({id:c.randomUUID(),commitTime:Date.now(),assets:[]}))" "$RESOURCE_DEST/app.manifest"
+          export SKIP_BUNDLING=1`
 
   const patch = `
     ${EXPO_UPDATES_METRO_SKIP_MARKER}
@@ -701,9 +763,8 @@ function injectExpoUpdatesIosResourcesPatchIntoPodfile(podfile) {
           fi
 
           mkdir -p "$RESOURCE_DEST"
-          "\${NODE_BINARY:-node}" -e "const c=require('node:crypto');const f=require('node:fs');f.writeFileSync(process.argv[1],JSON.stringify({id:c.randomUUID(),commitTime:Date.now(),assets:[]}))" "$RESOURCE_DEST/app.manifest"
 
-          export SKIP_BUNDLING=1
+${prelude}
 
           #{original_script}
         SCRIPT

--- a/packages/vxrn/expo-plugin.test.mjs
+++ b/packages/vxrn/expo-plugin.test.mjs
@@ -49,19 +49,41 @@ describe('injectHermesMinificationPatchIntoPodfile', () => {
 })
 
 describe('injectExpoUpdatesIosResourcesPatchIntoPodfile', () => {
-  it('injects the marker and patches the EXUpdates resources phase', () => {
+  it('defaults to real-manifest mode', () => {
     const out = injectExpoUpdatesIosResourcesPatchIntoPodfile(samplePodfile)
 
     expect(out).toContain(EXPO_UPDATES_METRO_SKIP_MARKER)
     expect(out).toContain("target.name == 'EXUpdates'")
     expect(out).toContain('Generate updates resources for expo-updates')
-    expect(out).toContain('SKIP_BUNDLING=1')
-    expect(out).toContain('app.manifest')
+    expect(out).toContain('export EXPO_NO_METRO_WORKSPACE_ROOT=1')
+    expect(out).not.toContain('SKIP_BUNDLING=1')
+    expect(out).not.toMatch(/assets:\[\]/)
   })
 
-  it('is idempotent', () => {
+  it('falls back to empty-placeholder mode when generateRealManifest is false', () => {
+    const out = injectExpoUpdatesIosResourcesPatchIntoPodfile(samplePodfile, {
+      generateRealManifest: false,
+    })
+
+    expect(out).toContain(EXPO_UPDATES_METRO_SKIP_MARKER)
+    expect(out).toContain('SKIP_BUNDLING=1')
+    expect(out).toContain('assets:[]')
+    expect(out).not.toContain('EXPO_NO_METRO_WORKSPACE_ROOT')
+  })
+
+  it('is idempotent in the default mode', () => {
     const once = injectExpoUpdatesIosResourcesPatchIntoPodfile(samplePodfile)
     const twice = injectExpoUpdatesIosResourcesPatchIntoPodfile(once)
+    expect(twice).toBe(once)
+  })
+
+  it('is idempotent in empty-placeholder mode too', () => {
+    const once = injectExpoUpdatesIosResourcesPatchIntoPodfile(samplePodfile, {
+      generateRealManifest: false,
+    })
+    const twice = injectExpoUpdatesIosResourcesPatchIntoPodfile(once, {
+      generateRealManifest: false,
+    })
     expect(twice).toBe(once)
   })
 


### PR DESCRIPTION
## Summary

Flips the default of `injectExpoUpdatesIosResourcesPatchIntoPodfile` so the EXUpdates pod's iOS build phase generates a real `app.manifest` matching the assets vxrn writes into the `.app`, instead of an empty placeholder. The previous behavior is preserved as an opt-out.

## Why

The vxrn iOS Podfile config plugin wraps the EXUpdates pod's `[CP-User] Generate updates resources for expo-updates` build phase. Until this PR, the wrapped script:

1. wrote a hardcoded `EXUpdates.bundle/app.manifest` of `{ "id": ..., "commitTime": ..., "assets": [] }`
2. exported `SKIP_BUNDLING=1`
3. invoked the upstream `create-updates-resources-ios.sh`, which (because of `SKIP_BUNDLING=1`) skipped the real manifest generation and only ran the fingerprint side-effects

The reason was that Expo Metro can't resolve the One entry on most pnpm monorepos without `EXPO_NO_METRO_WORKSPACE_ROOT=1`, so vxrn short-circuited the bundle step entirely.

The cost: at runtime `expo-asset` reads `ExpoUpdates.localAssets` (sourced from `app.manifest`) and returns a literal `{ uri: '', hash }` placeholder when the lookup misses. Every `require()`'d project-local asset resolved to `uri: ""` and `<Image>` silently rendered blank. Downstream apps have been working around this with JS-side `onError` fallbacks to a hosted copy of each asset.

## The fix

By default the wrapped build phase now exports `EXPO_NO_METRO_WORKSPACE_ROOT=1` and runs the upstream `create-updates-resources-ios.sh`. The generated manifest's `nsBundleDir` / `nsBundleFilename` entries match the asset paths vxrn writes into the `.app`, so `getLocalAssetUri` returns a real `file://.../.expo-internal/<hash>.png` URI and the embedded image loads on first launch.

For the end-to-end fix to actually produce non-blank URIs, the consuming app's Metro config also has to pin `server.unstable_serverRoot` to its `projectRoot` for release-shaped native bundles. The OTA docs section now walks through both pieces. Without server-root pinning, vxrn writes assets at workspace-relative paths while the manifest points at project-relative paths — same blank-URI symptom as before, no build-time regression.

## Why default-on is safe right now

The expo-updates integration just landed and is not yet announced — no published consumer is depending on the empty-placeholder behavior, so flipping the default doesn't break anyone.

Apps that need the old behavior anyway (very large bundles where the extra Metro server startup in the build phase is costly, or apps with no project-local `require()`'d images at all) can opt back in:

```json
// ios/Podfile.properties.json
{ "one.useEmptyExpoUpdatesManifest": "true" }
```

## What's in the diff

- `packages/vxrn/expo-plugin.cjs` — function now takes `{ generateRealManifest: boolean }`, defaults to `true`. The shell snippet branches on that. Public marker constant is preserved verbatim so existing patched Podfiles re-trigger the idempotency check on next `pod install` instead of getting the patch injected twice.
- `packages/vxrn/expo-plugin.test.mjs` — covers both modes and idempotency in each.
- `apps/onestack.dev/data/docs/guides-ota-updates.mdx` — adds the third piece (the EXUpdates manifest mode) to the existing "Monorepo asset resolution" section started earlier.

## Test plan

- [x] `bun run vitest run expo-plugin.test.mjs` — 9 passing (5 existing + 4 new for the two modes)
- [x] End-to-end verified against a downstream consumer (3PC, vite.config.ts already pins serverRoot): a prod-variant Release build on iPhone 16 Pro (iOS 18.6) sim now generates an `app.manifest` with all 16 assets including the project-local 3pc-logo, the runtime `Image.resolveAssetSource(require(...))` returns a `file://` URI, and the bundled image renders without firing the R2 `onError` fallback.
- [ ] Publish a canary and bump a couple of dependent apps to confirm the opt-out path works for someone who needs it.

## Notes for reviewers

- The marker constant string is intentionally unchanged. Tests assert that. Don't rename it without thinking about every Podfile that already contains it.
- The conditional shell snippet sits inside a Ruby heredoc inside a JS template literal — escaping is `\${VAR}` for shell variables, `${MARKER}` for JS interpolation. The current set of tests catches mis-escaping by checking for the actual emitted strings.